### PR TITLE
fix: test GH action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ jobs:
     container: ghcr.io/dopedao/ryo:latest
     steps:
       - uses: actions/checkout@v2
+      - name: install extra python dependencies
+        run: pip3 install 'pytest-xdist[psutil]' dill
       - name: compile
         run: bin/compile
       - name: test

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eu
 
-pytest -n auto -s -W ignore::DeprecationWarning ./testing/l2/00_Nft_marketplace_test.py
+pytest -n auto -W ignore::DeprecationWarning ./testing/l2/00_Nft_marketplace_test.py


### PR DESCRIPTION
Trying to fix the test Github Action.

The [`pytest-xdist`](https://pypi.org/project/pytest-xdist/) plugin isn't available in the execution container, hence the failure. When using xdist, the `-s` flag for pytest doesn't have any effect, so removing that as well.