### PR TITLE
BIP-3 Exchange ERC20 ERC1155

### DIFF
--- a/bin/compile_exchange
+++ b/bin/compile_exchange
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+nile compile contracts/token/*.cairo
+nile compile contracts/Account.cairo
+nile compile contracts/exchange/Exchange_ERC20_1155.cairo

--- a/bin/deploy_exchange
+++ b/bin/deploy_exchange
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -eu
+
+# Flow:
+## The Controller is the only unchangeable contract.
+## First deploy Arbiter.
+## Then send the Arbiter address during Controller deployment.
+## Then deploy Controller address during module deployments.
+
+# TODO: For a network_type node open a new shell and run:
+# Need to incorporate this into the script.
+# `nile node`
+
+# Network:
+network_type=localhost
+# network_type=mainnet
+
+# localhost is a ShardLabs devnet locally.
+# mainnet is currently Goerli/StarkNet-alpha
+
+
+# Wipe old deployment record if it exists.
+rm $network_type.deployments.txt || echo 'Will create one...'
+
+function get_address () {
+    # Read deployment address from $network_type.deployments.txt
+    local addr=`grep $1 $network_type.deployments.txt | cut -d ':' -f 1`
+    echo $addr
+}
+
+# Public keys of wallets (dummy/placeholder)
+declare -i AdminPubKey=12345678987654321
+declare -i User00PubKey=456456456
+
+# Admin account contract
+nile deploy Account $AdminPubKey \
+    --alias AdminAccount --network $network_type
+AdminAddress=`get_address "AdminAccount"`
+
+# Lords ERC20 contract 
+nile deploy ERC20_Mintable 328287282291 5001796 100000 0x5b39d5fe25926945c796697ba71156335c37d3049ef6e93c8d61aa47f05c998 0x5b39d5fe25926945c796697ba71156335c37d3049ef6e93c8d61aa47f05c998 0x5b39d5fe25926945c796697ba71156335c37d3049ef6e93c8d61aa47f05c998 \
+    --alias Lords --network $network_type
+LordsAddress=`get_address "Lords"`
+
+# Resources ERC1155 contract
+nile deploy ERC1155_Mintable 0x5b39d5fe25926945c796697ba71156335c37d3049ef6e93c8d61aa47f05c998 2 1 1 2 1000 2000 \
+    --alias Resources --network $network_type
+ResourcesAddress=`get_address "Resources"`
+
+# Exchange contract
+nile deploy Exchange_ERC20_1155 $LordsAddress $ResourcesAddress  \
+    --alias Exchange --network $network_type

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eu
 
-pytest -n auto -W ignore::DeprecationWarning ./testing/l2/00_Nft_marketplace_test.py
+pytest -n auto -W ignore::DeprecationWarning ./testing/l2/Exchange_ERC20_1155_test.py

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -528,7 +528,7 @@ func get_sell_price {
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
     }(
-        # Exact amount of token to buy
+        # Exact amount of token to sell
         token_amount: Uint256,
         # Currency reserve amount
         currency_reserves: Uint256,

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -74,7 +74,7 @@ func add_liquidity {
     }(
         max_currency_amount: Uint256,
         token_id: felt,
-        token_amount: felt,
+        token_amount: Uint256,
     ):
         #FIXME add deadline
         alloc_locals
@@ -86,7 +86,7 @@ func add_liquidity {
 
         IERC20.transferFrom(currency_addr, caller, contract, max_currency_amount)
         tempvar syscall_ptr :felt* = syscall_ptr
-        IERC1155.safeTransferFrom(token_addr, caller, contract, token_id, token_amount)
+        IERC1155.safeTransferFrom(token_addr, caller, contract, token_id, token_amount.low)
 
         #FIXME This is only for initial liquidity adds
         # Assert otherwise rounding error could end up being significant on second deposit
@@ -123,7 +123,7 @@ func buy_tokens {
     }(
         max_currency_amount: Uint256,
         token_id: felt,
-        token_amount: felt,
+        token_amount: Uint256,
     ) -> (
         sold: Uint256
     ):
@@ -146,7 +146,7 @@ func buy_tokens {
     #FIXME Fees / royalties
 
     # Calculate prices
-    let (currency_amount) = get_buy_price(Uint256(token_amount, 0), currency_res, Uint256(token_reserves, 0))
+    let (currency_amount) = get_buy_price(token_amount, currency_res, Uint256(token_reserves, 0))
 
     #TODO Fees
 
@@ -160,7 +160,7 @@ func buy_tokens {
     # Transfer refunded currency and purchased tokens
     IERC20.transfer(currency_addr, caller, refund_amount)
     tempvar syscall_ptr :felt* = syscall_ptr
-    IERC1155.safeTransferFrom(token_addr, contract, caller, token_id, token_amount)
+    IERC1155.safeTransferFrom(token_addr, contract, caller, token_id, token_amount.low)
 
     return (currency_amount)
 end
@@ -176,7 +176,7 @@ func sell_tokens {
     }(
         min_currency_amount: Uint256,
         token_id: felt,
-        token_amount: felt,
+        token_amount: Uint256,
     ) -> (
         sold: Uint256
     ):
@@ -193,10 +193,10 @@ func sell_tokens {
     let (token_reserves) = IERC1155.balanceOf(token_addr, contract, token_id)
 
     # Take the token amount
-    IERC1155.safeTransferFrom(token_addr, caller, contract, token_id, token_amount)
+    IERC1155.safeTransferFrom(token_addr, caller, contract, token_id, token_amount.low)
 
     # Calculate prices
-    let (currency_amount) = get_sell_price(Uint256(token_amount, 0), currency_res, Uint256(token_reserves, 0))
+    let (currency_amount) = get_sell_price(token_amount, currency_res, Uint256(token_reserves, 0))
 
     # Check min_currency_amount
     let (above_min_curr) = uint256_le(min_currency_amount, currency_amount)

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -1,6 +1,4 @@
-# Declare this file as a StarkNet contract and set the require builtins.
 %lang starknet
-%builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -258,6 +258,12 @@ func remove_liquidity {
         assert mul_overflow = Uint256(0, 0)
         let (tokens_owed, _) = uint256_unsigned_div_rem(numerator, lp_reserves_)
 
+        # Check minimums
+        let (above_zero) = uint256_le(min_currency_amount, currency_owed)
+        assert_not_zero(above_zero)
+        let (above_zero) = uint256_le(min_token_amount, tokens_owed)
+        assert_not_zero(above_zero)
+
         # New totals
         let (new_currency) = uint256_sub(currency_reserves_, currency_owed)
 

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -165,6 +165,7 @@ func buy_tokens {
 
     # Update reserves
     let (new_reserves, _) = uint256_add(currency_res, currency_amount)
+    currency_reserves.write(new_reserves)
 
     # Transfer refunded currency and purchased tokens
     IERC20.transfer(currency_addr, caller, refund_amount)
@@ -216,7 +217,8 @@ func sell_tokens {
     tempvar syscall_ptr :felt* = syscall_ptr
 
     # Update reserves
-    let (new_reserves, _) = uint256_add(currency_res, currency_amount)
+    let (new_reserves) = uint256_sub(currency_res, currency_amount)
+    currency_reserves.write(new_reserves)
 
     return (currency_amount)
 end

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -23,8 +23,6 @@ from contracts.token.ERC1155.ERC1155_base import (
     ERC1155_assert_is_owner_or_approved,
 )
 
-#FIXME Non-reentrant
-
 @event
 func liquidity_added(
         caller: felt,
@@ -134,7 +132,7 @@ func initial_liquidity {
         IERC1155.safeTransferFrom(token_address_, caller, contract, token_id, token_amount.low)
 
         # Assert otherwise rounding error could end up being significant on second deposit
-        let (ok) = uint256_le(Uint256(1000, 0), currency_amount) #FIXME
+        let (ok) = uint256_le(Uint256(1000, 0), currency_amount)
         assert_not_zero(ok)
 
         # Update currency  reserve size for Token id before transfer

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -1,0 +1,60 @@
+# Declare this file as a StarkNet contract and set the require builtins.
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.starknet.common.syscalls import (get_caller_address, get_contract_address)
+from starkware.cairo.common.math import assert_nn_le, unsigned_div_rem
+from starkware.cairo.common.uint256 import (Uint256, uint256_le)
+
+from contracts.token.IERC20 import IERC20
+from contracts.token.ERC1155.IERC1155 import IERC1155
+
+# Contract Address of ERC20 address for this swap contract
+@storage_var
+func currency_address() -> (address : felt):
+end
+
+# Contract Address of ERC1155 address for this swap contract
+@storage_var
+func token_address() -> (address : felt):
+end
+
+@constructor
+func constructor {
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr,
+    }(
+        currency_address_: felt,
+        token_address_: felt,
+    ):
+        currency_address.write(currency_address_)
+        token_address.write(token_address_)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func get_currency_address {
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (address: felt):
+    let (address) = currency_address.read()
+    return (address)
+end
+
+@view
+func get_token_address {
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (address: felt):
+    let (address) = token_address.read()
+    return (address)
+end

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -5,13 +5,23 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
-from starkware.cairo.common.math import assert_nn_le, unsigned_div_rem, assert_not_zero
+from starkware.cairo.common.math import assert_nn, assert_le, unsigned_div_rem, assert_not_zero
 from starkware.cairo.common.uint256 import (
     Uint256, uint256_add, uint256_sub, uint256_le, uint256_lt, uint256_check
 )
 
 from contracts.token.IERC20 import IERC20
 from contracts.token.ERC1155.IERC1155 import IERC1155
+from contracts.token.ERC1155.ERC1155_struct import TokenUri
+from contracts.token.ERC1155.ERC1155_base import (
+    # ERC1155_transfer_from,
+    # ERC1155_batch_transfer_from,
+    ERC1155_mint,
+    # ERC1155_URI,
+    # ERC1155_set_approval_for_all,
+    # ERC1155_balances,
+    # ERC1155_assert_is_owner_or_approved
+)
 
 # Contract Address of ERC20 address for this swap contract
 @storage_var
@@ -21,6 +31,23 @@ end
 # Contract Address of ERC1155 address for this swap contract
 @storage_var
 func token_address() -> (address : felt):
+end
+
+# Current reserves of currency
+#FIXME Per token
+@storage_var
+func currency_reserves() -> (reserves : Uint256):
+end
+
+# Combined reserves of curreny
+@storage_var
+func currency_total() -> (total : Uint256):
+end
+
+# Total supplied currency
+#FIXME Per token
+@storage_var
+func supplies_total() -> (total : Uint256):
 end
 
 @constructor
@@ -51,15 +78,39 @@ func add_liquidity {
         token_id: felt,
         token_amount: felt,
     ):
+        #FIXME add deadline
         alloc_locals
-        let (caller) = get_caller_address()
+        let (caller) = get_caller_address() #FIXME method param
         let (contract) = get_contract_address()
 
         let (token_addr) = token_address.read()
         let (currency_addr) = currency_address.read()
 
-        IERC1155.safeTransferFrom(token_addr, caller, contract, token_id, token_amount)
         IERC20.transferFrom(currency_addr, caller, contract, max_currency_amount)
+        tempvar syscall_ptr :felt* = syscall_ptr
+        IERC1155.safeTransferFrom(token_addr, caller, contract, token_id, token_amount)
+
+        #FIXME This is only for initial liquidity adds
+        # Assert otherwise rounding error could end up being significant on second deposit
+        # let (ok) = uint256_le(max_currency_amount, Uint256(0, 0))
+        # assert_not_zero(ok)
+        # let (ok) = uint256_le(Uint256(1000, 0), max_currency_amount)
+        # assert_not_zero(ok)
+
+        # Update currency  reserve size for Token id before transfer
+        currency_reserves.write(max_currency_amount)
+
+        # Update totalCurrency
+        currency_total.write(max_currency_amount)
+
+        # Initial liquidity is amount deposited (Incorrect pricing will be arbitraged)
+        supplies_total.write(max_currency_amount)
+
+        # Mint LP tokens
+        ERC1155_mint(caller, token_id, max_currency_amount.low)
+
+        #TODO emit LP Added Event
+
     return ()
 end
 
@@ -84,3 +135,42 @@ func get_token_address {
     }() -> (token_address: felt):
     return token_address.read()
 end
+
+
+
+
+
+# #
+# # Exchange is ERC1155 compliant as LP tokens are ERC1155
+# #
+
+# @external
+# func SetURI{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(uri_ : TokenUri):
+#     ERC1155_URI.write(uri_)
+#     return ()
+# end
+
+# @external
+# func setApprovalForAll{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+#         operator : felt, approved : felt):
+#     let (account) = get_caller_address()
+#     ERC1155_set_approval_for_all(operator, approved)
+#     return ()
+# end
+
+# @external
+# func safeTransferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+#         sender : felt, recipient : felt, token_id : felt, amount : felt):
+#     ERC1155_assert_is_owner_or_approved(sender)
+#     ERC1155_transfer_from(sender, recipient, token_id, amount)
+#     return ()
+# end
+
+# @external
+# func safeBatchTransferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
+#         sender : felt, recipient : felt, tokens_id_len : felt, tokens_id : felt*,
+#         amounts_len : felt, amounts : felt*):
+#     ERC1155_assert_is_owner_or_approved(sender)
+#     ERC1155_batch_transfer_from(sender, recipient, tokens_id_len, tokens_id, amounts_len, amounts)
+#     return ()
+# end

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -25,6 +25,42 @@ from contracts.token.ERC1155.ERC1155_base import (
 
 #FIXME Non-reentrant
 
+@event
+func liquidity_added(
+        caller: felt,
+        currency_amount: Uint256,
+        token_id: felt,
+        token_amount: Uint256,
+    ):
+end
+
+@event
+func liquidity_removed(
+        caller: felt,
+        currency_amount: Uint256,
+        token_id: felt,
+        token_amount: Uint256,
+    ):
+end
+
+@event
+func tokens_purchased(
+        caller: felt,
+        currency_sold: Uint256,
+        token_id: felt,
+        tokens_bought: Uint256,
+    ):
+end
+
+@event
+func currency_purchased(
+        caller: felt,
+        currency_bought: Uint256,
+        token_id: felt,
+        tokens_sold: Uint256,
+    ):
+end
+
 # Contract Address of ERC20 address for this swap contract
 @storage_var
 func currency_address() -> (address : felt):
@@ -110,7 +146,8 @@ func initial_liquidity {
         # Mint LP tokens
         ERC1155_mint(caller, token_id, currency_amount.low)
 
-        #TODO emit LP Added Event
+        # Emit event
+        liquidity_added.emit(caller, currency_amount, token_id, token_amount)
 
     return ()
 end
@@ -173,7 +210,8 @@ func add_liquidity {
         # Mint LP tokens
         ERC1155_mint(caller, token_id, currency_amount.low)
 
-        #TODO emit LP Added Event
+        # Emit event
+        liquidity_added.emit(caller, currency_amount, token_id, token_amount)
 
     return ()
 end
@@ -234,7 +272,8 @@ func remove_liquidity {
         tempvar syscall_ptr :felt* = syscall_ptr
         IERC1155.safeTransferFrom(token_address_, contract, caller, token_id, tokens_owed.low)
 
-        #TODO emit LP Removed Event
+        # Emit event
+        liquidity_removed.emit(caller, currency_owed, token_id, tokens_owed)
 
     return ()
 end
@@ -292,6 +331,9 @@ func buy_tokens {
     tempvar syscall_ptr :felt* = syscall_ptr
     IERC1155.safeTransferFrom(token_address_, contract, caller, token_id, token_amount.low)
 
+    # Emit event
+    tokens_purchased.emit(caller, currency_amount, token_id, token_amount)
+
     return (currency_amount)
 end
 
@@ -342,6 +384,9 @@ func sell_tokens {
     # Update reserves
     let (new_reserves) = uint256_sub(currency_reserves_, currency_amount)
     currency_reserves.write(token_id, new_reserves)
+
+    # Emit event
+    currency_purchased.emit(caller, currency_amount, token_id, token_amount)
 
     return (currency_amount)
 end

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -260,7 +260,6 @@ func buy_tokens {
     ) -> (
         sold: Uint256
     ):
-    #FIXME Recipient as a param
     alloc_locals
 
     let (block_timestamp) = get_block_timestamp()
@@ -279,12 +278,8 @@ func buy_tokens {
     IERC20.transferFrom(currency_address_, caller, contract, max_currency_amount)
     tempvar syscall_ptr :felt* = syscall_ptr
 
-    #FIXME Fees / royalties
-
     # Calculate prices
     let (currency_amount) = get_buy_price(token_amount, currency_reserves_, Uint256(token_reserves, 0))
-
-    #TODO Fees
 
     # Calculate refund
     let (refund_amount) = uint256_sub(max_currency_amount, currency_amount)
@@ -318,7 +313,6 @@ func sell_tokens {
     ) -> (
         sold: Uint256
     ):
-    #FIXME Add deadline
     alloc_locals
 
     let (block_timestamp) = get_block_timestamp()

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -134,6 +134,8 @@ func buy_tokens {
         max_currency_amount: Uint256,
         token_id: felt,
         token_amount: felt,
+    ) -> (
+        sold: Uint256
     ):
     #FIXME Add deadline
     #FIXME Recipient as a param
@@ -143,41 +145,15 @@ func buy_tokens {
 
     let (token_addr) = token_address.read()
     let (currency_addr) = currency_address.read()
+    
+    let (currency_res) = currency_reserves.read()
+    let (token_reserves) = IERC1155.balanceOf(token_addr, contract, token_id)
 
     # Transfer max currency
     IERC20.transferFrom(currency_addr, caller, contract, max_currency_amount)
     tempvar syscall_ptr :felt* = syscall_ptr
 
     #FIXME Fees / royalties
-
-    # Calculate token amount and execute
-    currency_to_token(max_currency_amount, token_id, token_amount)
-
-    return ()
-end
-
-
-@view
-func currency_to_token {
-        syscall_ptr : felt*,
-        pedersen_ptr : HashBuiltin*,
-        range_check_ptr
-    }(
-        max_currency_amount: Uint256,
-        token_id: felt,
-        token_amount: felt,
-    ) -> (
-        sold: Uint256
-    ):
-    alloc_locals
-
-    let (caller) = get_caller_address()
-    let (contract) = get_contract_address()
-
-    let (currency_res) = currency_reserves.read()
-    let (currency_addr) = currency_address.read()
-    let (token_addr) = token_address.read()
-    let (token_reserves) = IERC1155.balanceOf(token_addr, contract, token_id)
 
     # Calculate prices
     let (currency_amount) = get_buy_price(Uint256(token_amount, 0), currency_res, Uint256(token_reserves, 0))

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -376,6 +376,10 @@ func buy_tokens {
 
     # Calculate prices
     let (currency_amount) = get_buy_price(token_amount, currency_reserves_, Uint256(token_reserves, 0))
+    let (above_max_curr) = uint256_le(currency_amount, max_currency_amount)
+    with_attr error_message("Maximum currency amount exceeded"):
+        assert_not_zero(above_max_curr)
+    end
 
     # Calculate refund
     let (refund_amount) = uint256_sub(max_currency_amount, currency_amount)

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -4,7 +4,7 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc
-from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
+from starkware.starknet.common.syscalls import get_caller_address, get_contract_address, get_block_timestamp
 from starkware.cairo.common.math import assert_nn, assert_le, assert_not_zero
 from starkware.cairo.common.math_cmp import is_not_zero
 from starkware.cairo.common.uint256 import (
@@ -127,9 +127,13 @@ func add_liquidity {
         max_currency_amount: Uint256,
         token_id: felt,
         token_amount: Uint256,
+        deadline: felt,
     ):
-        #FIXME add deadline
         alloc_locals
+
+        let (block_timestamp) = get_block_timestamp()
+        assert_le(block_timestamp, deadline)
+
         let (caller) = get_caller_address()
         let (contract) = get_contract_address()
 
@@ -187,9 +191,13 @@ func remove_liquidity {
         token_id: felt,
         min_token_amount: Uint256,
         lp_amount: Uint256,
+        deadline: felt,
     ):
-        #FIXME add deadline
         alloc_locals
+
+        let (block_timestamp) = get_block_timestamp()
+        assert_le(block_timestamp, deadline)
+
         let (caller) = get_caller_address()
         let (contract) = get_contract_address()
 
@@ -248,12 +256,16 @@ func buy_tokens {
         max_currency_amount: Uint256,
         token_id: felt,
         token_amount: Uint256,
+        deadline: felt,
     ) -> (
         sold: Uint256
     ):
-    #FIXME Add deadline
     #FIXME Recipient as a param
     alloc_locals
+
+    let (block_timestamp) = get_block_timestamp()
+    assert_le(block_timestamp, deadline)
+
     let (caller) = get_caller_address()
     let (contract) = get_contract_address()
 
@@ -302,11 +314,16 @@ func sell_tokens {
         min_currency_amount: Uint256,
         token_id: felt,
         token_amount: Uint256,
+        deadline: felt,
     ) -> (
         sold: Uint256
     ):
     #FIXME Add deadline
     alloc_locals
+
+    let (block_timestamp) = get_block_timestamp()
+    assert_le(block_timestamp, deadline)
+
     let (caller) = get_caller_address()
     let (contract) = get_contract_address()
 

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -44,9 +44,8 @@ func get_currency_address {
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }() -> (address: felt):
-    let (address) = currency_address.read()
-    return (address)
+    }() -> (currency_address: felt):
+    return currency_address.read()
 end
 
 @view
@@ -54,7 +53,6 @@ func get_token_address {
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr
-    }() -> (address: felt):
-    let (address) = token_address.read()
-    return (address)
+    }() -> (token_address: felt):
+    return token_address.read()
 end

--- a/contracts/exchange/README.md
+++ b/contracts/exchange/README.md
@@ -1,0 +1,158 @@
+# Exchange ERC20 ERC1155
+
+The exchange contract allows trades between pairs of ERC20 and ERC1155 contract tokens.
+The contract is based on the [NiftyswapExchange20.sol contract](https://github.com/0xsequence/niftyswap/blob/master/src/contracts/exchange/NiftyswapExchange20.sol) and it's [specifications](https://github.com/0xsequence/niftyswap/blob/master/SPECIFICATIONS.md).
+
+One deployed contract will handle pairs between the ERC20 currency and all the tokens on a ERC1155.
+Each pair is has it's price curve tracked individually.
+Price changes on one token pair will not affect another.
+
+The exchange contract itself is ERC1155 compliant and will issue LP tokens with a token type id corresponding to the token type id in the pair.
+These tokens can be freely traded or used in other DeFi applications.
+
+## Terminology and Naming Conventions
+
+The ERC20 token is defined as the *currency*.
+
+The ERC1155 token is defined as the *token*.
+
+Some variables have a trailing underscore `_` to prevent collisions.
+
+*Pair* is used to describe a price curve between the currency and a single token type on the token contract.
+
+## Contract Interactions
+
+The contract can be broken into a number of sections:
+
+* Initialisation
+* Liquidity
+* Swaps
+
+### Initialisation
+
+The exchange is initialised through the constructor and initial liquidity pool addition.
+
+#### Constructor
+
+Each deployment of the contract will work with pairs between an ERC20 contract and all the tokens on an ERC1155 contract. This means one contract can manage multiple exchange pairs. 
+
+The constructor takes the address for the ERC20 and ERC1155 token contracts, and the liquidity provider fee.
+
+The liquidity provider fee is provided in the thousandths. e.g. A value of 15 would equate to a 1.5% fee on trades.
+
+#### Initial Liquidity
+
+Use this method to provide the initial liquidity to a pair.
+
+This method is only available for the first time liquidty is added to a pair. If you are creating pairs between multiple tokens on the ERC1155 contract, this method will need to be called for each pair.
+
+When calling this method you provide the currency amount, ERC1155 token type id and the token amount.
+This sets the initial price of the pair. We expect any large enough variation in pricing to be corrected via arbitrage.
+
+The exchange issues liquidity pool tokens equivalent to the supplied currency.
+
+### Liquidity
+
+After initialisation, liquidity can be freely added or removed from the pools using the methods below.
+
+Note, fees are recovered during swaps and so there is no reference to fees during liquidity pool interactions.
+
+#### Add Liquidity
+
+Use this method to add subsequent liquidity to an existing pair.
+
+This method is called with:
+
+* The maximum amount of currency the caller is willing to spend when adding liquidity
+* The token type id they are supplying liquidity for
+* The exact amount of tokens the caller will spend when adding liquidity
+* A maximum timestamp which the transaction must be accepted by
+
+Liquidty is supplied at the current price point in the `x * y = k` curve.
+
+Due to the fluctations in price as swaps are made, the caller may not know the exact amount of currency that will be required to supply the liquidity pool until the transaction is accepted. 
+The caller instead supplies the maximum amount of currency they are willing to spend. This acts a measure of slippage.
+
+The exchange issues liquidity pool tokens equivalent to the supplied currency.
+
+#### Remove Liquidity
+
+Use this method to redeem tokens supplied to the liquidty pool, by burning liquidity pool tokens.
+
+This method is called with:
+
+* The minimum amount of currency the caller is willing to receive when removing liquidity
+* The token type id they are removing liquidity for
+* The minimum amount of tokens the caller is willing to receive when removing liquidity
+* The exact amount of liquidity pool tokens to spend
+* A maximum timestamp which the transaction must be accepted by
+
+Liquidty is remove at the current price point in the `x * y = k` curve.
+
+Due to the fluctations in price as swaps are made, the caller may not know the exact amount of currency or tokens that will be recieved when removing liquidity from the pool until the transaction is accepted.
+The caller instead supplies the minimum amount of currency and tokens they are willing to receive. This acts a measure of slippage.
+
+The exchange burns liquidity pool tokens supplied in the call.
+
+### Swaps
+
+Swaps are performed as either buy or sell actions.
+
+When making a swap, the exchange will calculate the price according to the `x * y = k` curve.
+Fees are collected against the currency in both buy and sell actions.
+Due to this, `k` will steadly increase as a measure to collect rewards for the liquidity providers.
+When liquidity is removed from the pools, as `k` has increased, their proportional share in the pool will have increased as well.
+
+#### Buy Tokens
+
+Use this method to purchase tokens with currency.
+
+This method is called with:
+
+* The maximum amount of currency the caller is willing to spend when swapping
+* The token type id they are swapping
+* The exact amount of tokens the caller will receive when swapping
+* A maximum timestamp which the transaction must be accepted by
+
+See the above Swap section for information about the pricing curve.
+
+Due to the fluctations in price as swaps are made, the caller may not know the exact amount of currency that will be required to swap until the transaction is accepted. 
+The caller instead supplies the maximum amount of currency they are willing to spend. This acts a measure of slippage.
+
+#### Sell Tokens
+
+Use this method to sell tokens for currency.
+
+This method is called with:
+
+* The minimum amount of currency the caller is willing to receive when swapping
+* The token type id they are swapping
+* The exact amount of tokens the caller will spend when swapping
+* A maximum timestamp which the transaction must be accepted by
+
+See the above Swap section for information about the pricing curve.
+
+Due to the fluctations in price as swaps are made, the caller may not know the exact amount of currency that will be required to swap until the transaction is accepted. 
+The caller instead supplies the minimum amount of currency they are willing to receive. This acts a measure of slippage.
+
+#### Get Buy / Sell Price
+
+The `get_buy_price` and `get_sell_price` functions are read only functions used to get the current price according to the `x * y = k` curve, and take into considering the exchange fee.
+These methods are separated from the buy and sell methods so that they can be used for price display on frontends.
+
+The liquidity provider fee is stored in the thousandths. e.g. A value of `15` would equate to a 1.5% fee on trades. Thus `1000` is used as a static value in these calculations.
+
+### Misc Getters
+
+There are additional getters for the following stored values:
+
+* Currency contract address
+* Token contract address
+* Currency reserves (for the given token type id)
+* LP fee (in thousandths)
+
+The contract does not store a value for the ERC1155 token reserves and instead relies on the `balanceOf` ERC1155 function.
+
+### LP ERC 1155 Compliance
+
+There are additional method to support the ERC1155 compliance of LP tokens provided by this contract.

--- a/contracts/exchange/README.md
+++ b/contracts/exchange/README.md
@@ -1,10 +1,10 @@
 # Exchange ERC20 ERC1155
 
 The exchange contract allows trades between pairs of ERC20 and ERC1155 contract tokens.
-The contract is based on the [NiftyswapExchange20.sol contract](https://github.com/0xsequence/niftyswap/blob/master/src/contracts/exchange/NiftyswapExchange20.sol) and it's [specifications](https://github.com/0xsequence/niftyswap/blob/master/SPECIFICATIONS.md).
+The contract is based on the [NiftyswapExchange20.sol contract](https://github.com/0xsequence/niftyswap/blob/master/src/contracts/exchange/NiftyswapExchange20.sol) and its [specifications](https://github.com/0xsequence/niftyswap/blob/master/SPECIFICATIONS.md).
 
 One deployed contract will handle pairs between the ERC20 currency and all the tokens on a ERC1155.
-Each pair is has it's price curve tracked individually.
+Each pair has it's price curve tracked individually.
 Price changes on one token pair will not affect another.
 
 The exchange contract itself is ERC1155 compliant and will issue LP tokens with a token type id corresponding to the token type id in the pair.

--- a/contracts/exchange/README.md
+++ b/contracts/exchange/README.md
@@ -20,6 +20,8 @@ Some variables have a trailing underscore `_` to prevent collisions.
 
 *Pair* is used to describe a price curve between the currency and a single token type on the token contract.
 
+Functions named with `_loop` are used for recursive processing of lists of items.
+
 ## Contract Interactions
 
 The contract can be broken into a number of sections:

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -168,7 +168,7 @@ async def sell_and_check(admin_account, admin_signer, lords, resources, exchange
     assert uint(before_lords_bal[0] + currency_diff_required) == after_lords_bal
     assert before_resources_bal - token_to_sell == after_resources_bal
     after_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
-    assert before_currency_reserve + currency_diff_required == after_currency_reserve
+    assert before_currency_reserve - currency_diff_required == after_currency_reserve
 
 
 @pytest.mark.asyncio

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -1,4 +1,5 @@
 import pytest
+from fractions import Fraction
 import conftest
 from utils import uint, assert_revert
 

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -270,39 +270,58 @@ async def buy_and_check(admin_account, admin_signer, ctx, resource_ids, token_to
     assert uint(before_lords_bal[0] - sum(expected_prices)) == after_lords_bal
 
 
-async def sell_and_check(admin_account, admin_signer, ctx, resource_id, token_to_sell, expected_price):
+async def sell_and_check(admin_account, admin_signer, ctx, resource_ids, token_to_sells, expected_prices):
     exchange = ctx.exchange
     lords = ctx.lords
     resources = ctx.resources
 
-    before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources, resource_id)
+    # Store before values for asserting after tests
+    befores = []
+    before_lords_bal = 0
 
-    before_currency_reserve = (await exchange.get_currency_reserves(resource_id).invoke()).result.currency_reserves[0]
-    token_reserve = (await resources.balanceOf(exchange.contract_address, resource_id).invoke()).result.balance
+    for i in range(0, len(resource_ids)):
+        before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources, resource_ids[i])
 
-    # Check price math
-    res = await exchange.get_sell_price(uint(token_to_sell), uint(before_currency_reserve), uint(token_reserve)).invoke()
-    assert res.result.price == uint(expected_price)
+        before_currency_reserve = (await exchange.get_currency_reserves(resource_ids[i]).invoke()).result.currency_reserves[0]
+        token_reserve = (await resources.balanceOf(exchange.contract_address, resource_ids[i]).invoke()).result.balance
+
+        # Check price math
+        res = await exchange.get_sell_price(uint(token_to_sells[i]), uint(before_currency_reserve), uint(token_reserve)).invoke()
+        assert res.result.price == uint(expected_prices[i])
+
+        befores.append({
+            'before_resources_bal': before_resources_bal,
+            'before_currency_reserve': before_currency_reserve,
+        })
 
     # Make sale
     current_time = conftest.get_block_timestamp(ctx.starknet.state)
-    min_currency = expected_price - 2 # Add a bit of fat
+    min_currency = sum(expected_prices) - 2 # Add a bit of fat
     await admin_signer.send_transaction(
         admin_account,
         exchange.contract_address,
         'sell_tokens',
         [
             *uint(min_currency),
-            resource_id,
-            *uint(token_to_sell),
+            len(resource_ids),
+            *resource_ids,
+            len(token_to_sells),
+            *list(sum([uint(b) for b in token_to_sells], ())), #uint values in list and expand
             current_time + 1000,
         ]
     )
-    after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources, resource_id)
-    assert uint(before_lords_bal[0] + expected_price) == after_lords_bal
-    assert before_resources_bal - token_to_sell == after_resources_bal
-    after_currency_reserve = (await exchange.get_currency_reserves(resource_id).invoke()).result.currency_reserves[0]
-    assert before_currency_reserve - expected_price == after_currency_reserve
+
+    # Check values
+    for i in range(0, len(resource_ids)):
+        res = await resources.balanceOf(admin_account.contract_address, resource_ids[i]).invoke()
+        after_resources_bal = res.result.balance
+        assert befores[i]['before_resources_bal'] - token_to_sells[i] == after_resources_bal
+        after_currency_reserve = (await exchange.get_currency_reserves(resource_ids[i]).invoke()).result.currency_reserves[0]
+        assert befores[i]['before_currency_reserve'] - expected_prices[i] == after_currency_reserve
+    # Check lords in bulk
+    res = await lords.balanceOf(admin_account.contract_address).invoke()
+    after_lords_bal = res.result.balance
+    assert uint(before_lords_bal[0] + sum(expected_prices)) == after_lords_bal
 
 
 @pytest.mark.asyncio
@@ -362,15 +381,18 @@ async def test_sell_price(exchange_factory):
     currency_reserve = 1000
     token_reserve = 1000
     token_id = 3
+    token_id2 = 5
 
     await initial_liq(admin_signer, admin_account, ctx, currency_reserve, token_id, token_reserve)
     # price = (amnt * cur_res * (1000 - fee)) / ((tok_res * 1000) + (amnt * (1000 - fee)))
     # price = (100 * 1000 * (1000 - 100)) / (1000 * 1000 + (100 * (1000 - 100)))
     # price = 82
-    await sell_and_check(admin_account, admin_signer, ctx, token_id, 100, 82)
+    await sell_and_check(admin_account, admin_signer, ctx, [token_id], [100], [82])
     # price = (100 * (1000 - 100) * 918) / (1100 * 1000 + (100 * (1000 - 100)))
     # price = 69
-    await sell_and_check(admin_account, admin_signer, ctx, token_id, 100, 69)
+    # Second value has same LP value, price, amounts as the first buy_and_check request
+    await initial_liq(admin_signer, admin_account, ctx, currency_reserve, token_id2, token_reserve)
+    await sell_and_check(admin_account, admin_signer, ctx, [token_id, token_id2], [100, 100], [69, 82])
 
     # Test increased min fails
     sell_amount = 100

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -1,4 +1,5 @@
 import pytest
+from utils import uint
 
 @pytest.fixture(scope='module')
 async def exchange_factory(ctx_factory):
@@ -7,7 +8,7 @@ async def exchange_factory(ctx_factory):
 
     exchange = await ctx.starknet.deploy(
         source="contracts/exchange/Exchange_ERC20_1155.cairo",
-        constructor_calldata = [
+        constructor_calldata=[
             ctx.lords.contract_address,
             ctx.resources.contract_address,
         ]
@@ -25,9 +26,59 @@ async def test_check_addr(exchange_factory):
     exchange = ctx.exchange
 
     res = await exchange.get_currency_address().call()
-    print(res.result)
     assert res.result.currency_address == (ctx.lords.contract_address)
 
     res = await exchange.get_token_address().call()
-    print(res.result)
     assert res.result.token_address == (ctx.resources.contract_address)
+
+
+@pytest.mark.asyncio
+async def test_add_liquidity(exchange_factory):
+    print("test_add_liquidity")
+    ctx = exchange_factory
+    admin_signer = ctx.signers['admin']
+    admin = ctx.admin
+    exchange = ctx.exchange
+    lords = ctx.lords
+    resources = ctx.resources
+    max_currency = 10000
+    token_spent = 1000
+
+    # Before states
+    res = await lords.balanceOf(admin.contract_address).call()
+    before_lords_bal = res.result.balance
+    res = await resources.balanceOf(admin.contract_address, 1).call()
+    before_resources_bal = res.result.balance
+
+    # Approve access
+    await admin_signer.send_transaction(
+        admin,
+        lords.contract_address,
+        'approve',
+        [exchange.contract_address, *uint(max_currency)]
+    )
+    await admin_signer.send_transaction(
+        admin,
+        resources.contract_address,
+        'setApprovalForAll',
+        [exchange.contract_address, True]
+    )
+
+    # Provide liquidity
+    await admin_signer.send_transaction(
+        admin,
+        exchange.contract_address,
+        'add_liquidity',
+        [*uint(max_currency), 1, token_spent]
+    )
+
+    # After states
+    res = await lords.balanceOf(admin.contract_address).call()
+    assert uint(before_lords_bal[0] - max_currency) == res.result.balance
+    res = await resources.balanceOf(admin.contract_address, 1).call()
+    assert before_resources_bal - token_spent == res.result.balance
+    # Contract balances
+    res = await lords.balanceOf(exchange.contract_address).call()
+    assert res.result.balance == uint(max_currency)
+    res = await resources.balanceOf(exchange.contract_address, 1).call()
+    assert res.result.balance == token_spent

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -170,6 +170,32 @@ async def test_liquidity(exchange_factory):
             current_time + 1000,
         ]
     )
+    # Cannot remove liquidity when min amounts not met
+    await assert_revert(admin_signer.send_transaction(
+        admin_account,
+        exchange.contract_address,
+        'remove_liquidity',
+        [
+            *uint(currency_amount + 100),
+            token_id,
+            *uint(token_spent),
+            *uint(currency_amount),
+            current_time + 1000,
+        ]
+    ))
+    await assert_revert(admin_signer.send_transaction(
+        admin_account,
+        exchange.contract_address,
+        'remove_liquidity',
+        [
+            *uint(currency_amount),
+            token_id,
+            *uint(token_spent + 100),
+            *uint(currency_amount),
+            current_time + 1000,
+        ]
+    ))
+
     # After states
     after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources, token_id)
     assert uint(before_lords_bal[0] - currency_amount) == after_lords_bal

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -82,3 +82,6 @@ async def test_add_liquidity(exchange_factory):
     assert res.result.balance == uint(max_currency)
     res = await resources.balanceOf(exchange.contract_address, 1).call()
     assert res.result.balance == token_spent
+    # Check LP tokens
+    res = await exchange.balanceOf(admin_account.contract_address, 1).call()
+    assert res.result.balance == max_currency

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -41,7 +41,7 @@ async def set_erc20_allowance(signer, account, erc20, who, amount):
         [who, *uint(amount)]
     )
 
-async def provide_liq(admin_signer, admin_account, exchange, lords, resources, max_currency, token_spent):
+async def provide_liq(admin_signer, admin_account, exchange, lords, resources, max_currency, token_id, token_spent):
     # Approve access
     await set_erc20_allowance(admin_signer, admin_account, lords, exchange.contract_address, max_currency)
     await admin_signer.send_transaction(
@@ -56,7 +56,7 @@ async def provide_liq(admin_signer, admin_account, exchange, lords, resources, m
         admin_account,
         exchange.contract_address,
         'add_liquidity',
-        [*uint(max_currency), 1, token_spent]
+        [*uint(max_currency), token_id, token_spent]
     )
 
 
@@ -85,7 +85,7 @@ async def test_add_liquidity(exchange_factory):
     before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources)
 
     # Do it
-    await provide_liq(admin_signer, admin_account, exchange, lords, resources, max_currency, token_spent)
+    await provide_liq(admin_signer, admin_account, exchange, lords, resources, max_currency, 1, token_spent)
 
     # After states
     after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources)
@@ -183,7 +183,7 @@ async def test_buy_price(exchange_factory):
     currency_reserve = 10000
     token_reserve = 1000
 
-    await provide_liq(admin_signer, admin_account, exchange, lords, resources, currency_reserve, token_reserve)
+    await provide_liq(admin_signer, admin_account, exchange, lords, resources, currency_reserve, 1, token_reserve)
     # Buy and check twice
     await buy_and_check(admin_account, admin_signer, lords, resources, exchange, 1, 10)
     await buy_and_check(admin_account, admin_signer, lords, resources, exchange, 1, 10)
@@ -201,7 +201,7 @@ async def test_sell_price(exchange_factory):
     currency_reserve = 10000
     token_reserve = 1000
 
-    await provide_liq(admin_signer, admin_account, exchange, lords, resources, currency_reserve, token_reserve)
+    await provide_liq(admin_signer, admin_account, exchange, lords, resources, currency_reserve, 1, token_reserve)
     # Sell and check twice
     await sell_and_check(admin_account, admin_signer, lords, resources, exchange, 1, 10)
     await sell_and_check(admin_account, admin_signer, lords, resources, exchange, 1, 10)

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -130,7 +130,7 @@ async def buy_and_check(admin_account, admin_signer, lords, resources, exchange,
         [
             *uint(max_currency),
             1,
-            token_to_buy,
+            *uint(token_to_buy),
         ]
     )
     after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources)
@@ -161,7 +161,7 @@ async def sell_and_check(admin_account, admin_signer, lords, resources, exchange
         [
             *uint(min_currency),
             1,
-            token_to_sell,
+            *uint(token_to_sell),
         ]
     )
     after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources)

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -29,10 +29,10 @@ async def test_check_addr(exchange_factory):
     ctx = exchange_factory
     exchange = ctx.exchange
 
-    res = await exchange.get_currency_address().call()
+    res = await exchange.get_currency_address().invoke()
     assert res.result.currency_address == (ctx.lords.contract_address)
 
-    res = await exchange.get_token_address().call()
+    res = await exchange.get_token_address().invoke()
     assert res.result.token_address == (ctx.resources.contract_address)
 
 
@@ -98,9 +98,9 @@ async def add_liq(admin_signer, admin_account, ctx, max_currency, token_id, toke
 
 async def get_token_bals(account, lords, resources, token_id):
     """ Get the current balances. """
-    res = await lords.balanceOf(account.contract_address).call()
+    res = await lords.balanceOf(account.contract_address).invoke()
     before_lords_bal = res.result.balance
-    res = await resources.balanceOf(account.contract_address, token_id).call()
+    res = await resources.balanceOf(account.contract_address, token_id).invoke()
     before_resources_bal = res.result.balance
     return before_lords_bal, before_resources_bal
 
@@ -133,7 +133,7 @@ async def test_liquidity(exchange_factory):
     assert exchange_lords_bal == uint(currency_amount)
     assert exchange_resources_bal == token_spent
     # Check LP tokens
-    res = await exchange.balanceOf(admin_account.contract_address, token_id).call()
+    res = await exchange.balanceOf(admin_account.contract_address, token_id).invoke()
     assert res.result.balance == currency_amount
 
     # Add more liquidity using the same spread
@@ -147,7 +147,7 @@ async def test_liquidity(exchange_factory):
     assert exchange_lords_bal == uint(currency_amount * 2)
     assert exchange_resources_bal == token_spent * 2
     # Check LP tokens
-    res = await exchange.balanceOf(admin_account.contract_address, token_id).call()
+    res = await exchange.balanceOf(admin_account.contract_address, token_id).invoke()
     assert res.result.balance == currency_amount * 2
 
     # Remove liquidity
@@ -205,7 +205,7 @@ async def test_liquidity(exchange_factory):
     assert exchange_lords_bal == uint(currency_amount)
     assert exchange_resources_bal == token_spent
     # Check LP tokens
-    res = await exchange.balanceOf(admin_account.contract_address, token_id).call()
+    res = await exchange.balanceOf(admin_account.contract_address, token_id).invoke()
     assert res.result.balance == currency_amount
 
 
@@ -223,15 +223,15 @@ async def buy_and_check(admin_account, admin_signer, ctx, resource_id, token_to_
 
     before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources, resource_id)
 
-    before_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
-    token_reserve = (await resources.balanceOf(exchange.contract_address, resource_id).call()).result.balance
+    before_currency_reserve = (await exchange.get_currency_reserves(resource_id).invoke()).result.currency_reserves[0]
+    token_reserve = (await resources.balanceOf(exchange.contract_address, resource_id).invoke()).result.balance
 
     price = calc_d_x(before_currency_reserve, token_reserve, token_to_buy)
     fee = price * fee_percent
     currency_diff_required = math.ceil(price + fee)
 
     # Check price math
-    res = await exchange.get_buy_price(uint(token_to_buy), uint(before_currency_reserve), uint(token_reserve)).call()
+    res = await exchange.get_buy_price(uint(token_to_buy), uint(before_currency_reserve), uint(token_reserve)).invoke()
     assert res.result.price == uint(currency_diff_required)
 
     # Make sale
@@ -252,7 +252,7 @@ async def buy_and_check(admin_account, admin_signer, ctx, resource_id, token_to_
     after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources, resource_id)
     assert uint(before_lords_bal[0] - currency_diff_required) == after_lords_bal
     assert before_resources_bal + token_to_buy == after_resources_bal
-    after_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
+    after_currency_reserve = (await exchange.get_currency_reserves(resource_id).invoke()).result.currency_reserves[0]
     assert before_currency_reserve + currency_diff_required == after_currency_reserve
 
 
@@ -263,15 +263,15 @@ async def sell_and_check(admin_account, admin_signer, ctx, resource_id, token_to
 
     before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources, resource_id)
 
-    before_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
-    token_reserve = (await resources.balanceOf(exchange.contract_address, resource_id).call()).result.balance
+    before_currency_reserve = (await exchange.get_currency_reserves(resource_id).invoke()).result.currency_reserves[0]
+    token_reserve = (await resources.balanceOf(exchange.contract_address, resource_id).invoke()).result.balance
 
     price = -calc_d_x(before_currency_reserve, token_reserve, -token_to_sell)
     fee = price * fee_percent
     currency_diff_required = math.floor(price - fee)
 
     # Check price math
-    res = await exchange.get_sell_price(uint(token_to_sell), uint(before_currency_reserve), uint(token_reserve)).call()
+    res = await exchange.get_sell_price(uint(token_to_sell), uint(before_currency_reserve), uint(token_reserve)).invoke()
     assert res.result.price == uint(currency_diff_required)
 
     # Make sale
@@ -291,7 +291,7 @@ async def sell_and_check(admin_account, admin_signer, ctx, resource_id, token_to
     after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources, resource_id)
     assert uint(before_lords_bal[0] + currency_diff_required) == after_lords_bal
     assert before_resources_bal - token_to_sell == after_resources_bal
-    after_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
+    after_currency_reserve = (await exchange.get_currency_reserves(resource_id).invoke()).result.currency_reserves[0]
     assert before_currency_reserve - currency_diff_required == after_currency_reserve
 
 

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -1,4 +1,5 @@
 import pytest
+import math
 from utils import uint
 
 @pytest.fixture(scope='module')
@@ -32,33 +33,19 @@ async def test_check_addr(exchange_factory):
     assert res.result.token_address == (ctx.resources.contract_address)
 
 
-@pytest.mark.asyncio
-async def test_add_liquidity(exchange_factory):
-    print("test_add_liquidity")
-    ctx = exchange_factory
-    admin_signer = ctx.signers['admin']
-    admin = ctx.admin
-    exchange = ctx.exchange
-    lords = ctx.lords
-    resources = ctx.resources
-    max_currency = 10000
-    token_spent = 1000
-
-    # Before states
-    res = await lords.balanceOf(admin.contract_address).call()
-    before_lords_bal = res.result.balance
-    res = await resources.balanceOf(admin.contract_address, 1).call()
-    before_resources_bal = res.result.balance
-
-    # Approve access
-    await admin_signer.send_transaction(
-        admin,
-        lords.contract_address,
+async def set_erc20_allowance(signer, account, erc20, who, amount):
+    await signer.send_transaction(
+        account,
+        erc20.contract_address,
         'approve',
-        [exchange.contract_address, *uint(max_currency)]
+        [who, *uint(amount)]
     )
+
+async def provide_liq(admin_signer, admin_account, exchange, lords, resources, max_currency, token_spent):
+    # Approve access
+    await set_erc20_allowance(admin_signer, admin_account, lords, exchange.contract_address, max_currency)
     await admin_signer.send_transaction(
-        admin,
+        admin_account,
         resources.contract_address,
         'setApprovalForAll',
         [exchange.contract_address, True]
@@ -66,22 +53,96 @@ async def test_add_liquidity(exchange_factory):
 
     # Provide liquidity
     await admin_signer.send_transaction(
-        admin,
+        admin_account,
         exchange.contract_address,
         'add_liquidity',
         [*uint(max_currency), 1, token_spent]
     )
 
+
+async def get_token_bals(account, lords, resources):
+    """ Get the current balances. """
+    res = await lords.balanceOf(account.contract_address).call()
+    before_lords_bal = res.result.balance
+    res = await resources.balanceOf(account.contract_address, 1).call()
+    before_resources_bal = res.result.balance
+    return before_lords_bal, before_resources_bal
+
+
+@pytest.mark.asyncio
+async def xtest_add_liquidity(exchange_factory):
+    print("test_add_liquidity")
+    ctx = exchange_factory
+    admin_signer = ctx.signers['admin']
+    admin_account = ctx.admin
+    exchange = ctx.exchange
+    lords = ctx.lords
+    resources = ctx.resources
+    max_currency = 10000
+    token_spent = 1000
+
+    # Before states
+    before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources)
+
+    # Do it
+    await provide_liq(admin_signer, admin_account, exchange, lords, resources, max_currency, token_spent)
+
     # After states
-    res = await lords.balanceOf(admin.contract_address).call()
-    assert uint(before_lords_bal[0] - max_currency) == res.result.balance
-    res = await resources.balanceOf(admin.contract_address, 1).call()
-    assert before_resources_bal - token_spent == res.result.balance
+    after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources)
+    assert uint(before_lords_bal[0] - max_currency) == after_lords_bal
+    assert before_resources_bal - token_spent == after_resources_bal
     # Contract balances
-    res = await lords.balanceOf(exchange.contract_address).call()
-    assert res.result.balance == uint(max_currency)
-    res = await resources.balanceOf(exchange.contract_address, 1).call()
-    assert res.result.balance == token_spent
+    exchange_lords_bal, exchange_resources_bal = await get_token_bals(exchange, lords, resources)
+    assert exchange_lords_bal == uint(max_currency)
+    assert exchange_resources_bal == token_spent
     # Check LP tokens
     res = await exchange.balanceOf(admin_account.contract_address, 1).call()
     assert res.result.balance == max_currency
+
+
+def calc_price(old_x, old_y, d_y):
+    """ Find the new value of x in a x*y=k equation given dy. """
+    k = old_x * old_y
+    new_x = k / (old_y - d_y)
+    d_x = new_x - old_x
+    return math.floor(d_x)
+
+
+@pytest.mark.asyncio
+async def test_price(exchange_factory):
+    print("test_price")
+    ctx = exchange_factory
+    admin_signer = ctx.signers['admin']
+    admin_account = ctx.admin
+    exchange = ctx.exchange
+    lords = ctx.lords
+    resources = ctx.resources
+    currency_reserve = 10000
+    token_reserve = 1000
+    token_to_buy = 10
+
+    await provide_liq(admin_signer, admin_account, exchange, lords, resources, currency_reserve, token_reserve)
+    before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources)
+
+    currency_diff_required = calc_price(currency_reserve, token_reserve, token_to_buy)
+
+    # Check price math
+    res = await exchange.get_buy_price(uint(token_to_buy), uint(currency_reserve), uint(token_reserve)).call()
+    assert res.result.price == uint(currency_diff_required)
+
+    # Make purchase
+    usable_currency = currency_diff_required + 100 # Increment max currency to ensure correct buy price is used
+    await set_erc20_allowance(admin_signer, admin_account, lords, exchange.contract_address, usable_currency)
+    await admin_signer.send_transaction(
+        admin_account,
+        exchange.contract_address,
+        'buy_tokens',
+        [
+            *uint(usable_currency),
+            1,
+            token_to_buy,
+        ]
+    )
+    after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources)
+    assert uint(before_lords_bal[0] - currency_diff_required) == after_lords_bal
+    assert before_resources_bal + token_to_buy == after_resources_bal

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -217,7 +217,7 @@ async def sell_and_check(admin_account, admin_signer, lords, resources, exchange
     assert res.result.price == uint(currency_diff_required)
 
     # Make sale
-    min_currency = currency_diff_required - 10 # Add a bit of fat
+    min_currency = currency_diff_required - 2 # Add a bit of fat
     await admin_signer.send_transaction(
         admin_account,
         exchange.contract_address,

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -108,11 +108,11 @@ def calc_d_x(old_x, old_y, d_y):
     return d_x
 
 
-async def buy_and_check(admin_account, admin_signer, lords, resources, exchange, token_to_buy):
+async def buy_and_check(admin_account, admin_signer, lords, resources, exchange, resource_id, token_to_buy):
     before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources)
 
-    before_currency_reserve = (await exchange.get_currency_reserves().call()).result.currency_reserves[0]
-    token_reserve = (await resources.balanceOf(exchange.contract_address, 1).call()).result.balance
+    before_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
+    token_reserve = (await resources.balanceOf(exchange.contract_address, resource_id).call()).result.balance
 
     currency_diff_required = math.floor(calc_d_x(before_currency_reserve, token_reserve, token_to_buy))
 
@@ -136,15 +136,15 @@ async def buy_and_check(admin_account, admin_signer, lords, resources, exchange,
     after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources)
     assert uint(before_lords_bal[0] - currency_diff_required) == after_lords_bal
     assert before_resources_bal + token_to_buy == after_resources_bal
-    after_currency_reserve = (await exchange.get_currency_reserves().call()).result.currency_reserves[0]
+    after_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
     assert before_currency_reserve + currency_diff_required == after_currency_reserve
 
 
-async def sell_and_check(admin_account, admin_signer, lords, resources, exchange, token_to_sell):
+async def sell_and_check(admin_account, admin_signer, lords, resources, exchange, resource_id, token_to_sell):
     before_lords_bal, before_resources_bal = await get_token_bals(admin_account, lords, resources)
 
-    before_currency_reserve = (await exchange.get_currency_reserves().call()).result.currency_reserves[0]
-    token_reserve = (await resources.balanceOf(exchange.contract_address, 1).call()).result.balance
+    before_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
+    token_reserve = (await resources.balanceOf(exchange.contract_address, resource_id).call()).result.balance
 
     currency_diff_required = math.floor(-calc_d_x(before_currency_reserve, token_reserve, -token_to_sell))
 
@@ -167,7 +167,7 @@ async def sell_and_check(admin_account, admin_signer, lords, resources, exchange
     after_lords_bal, after_resources_bal = await get_token_bals(admin_account, lords, resources)
     assert uint(before_lords_bal[0] + currency_diff_required) == after_lords_bal
     assert before_resources_bal - token_to_sell == after_resources_bal
-    after_currency_reserve = (await exchange.get_currency_reserves().call()).result.currency_reserves[0]
+    after_currency_reserve = (await exchange.get_currency_reserves(resource_id).call()).result.currency_reserves[0]
     assert before_currency_reserve + currency_diff_required == after_currency_reserve
 
 
@@ -185,8 +185,8 @@ async def test_buy_price(exchange_factory):
 
     await provide_liq(admin_signer, admin_account, exchange, lords, resources, currency_reserve, token_reserve)
     # Buy and check twice
-    await buy_and_check(admin_account, admin_signer, lords, resources, exchange, 10)
-    await buy_and_check(admin_account, admin_signer, lords, resources, exchange, 10)
+    await buy_and_check(admin_account, admin_signer, lords, resources, exchange, 1, 10)
+    await buy_and_check(admin_account, admin_signer, lords, resources, exchange, 1, 10)
 
 
 @pytest.mark.asyncio
@@ -203,5 +203,5 @@ async def test_sell_price(exchange_factory):
 
     await provide_liq(admin_signer, admin_account, exchange, lords, resources, currency_reserve, token_reserve)
     # Sell and check twice
-    await sell_and_check(admin_account, admin_signer, lords, resources, exchange, 10)
-    await sell_and_check(admin_account, admin_signer, lords, resources, exchange, 10)
+    await sell_and_check(admin_account, admin_signer, lords, resources, exchange, 1, 10)
+    await sell_and_check(admin_account, admin_signer, lords, resources, exchange, 1, 10)

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -1,0 +1,33 @@
+import pytest
+
+@pytest.fixture(scope='module')
+async def exchange_factory(ctx_factory):
+    print("Constructing exchange factory")
+    ctx = ctx_factory()
+
+    exchange = await ctx.starknet.deploy(
+        source="contracts/exchange/Exchange_ERC20_1155.cairo",
+        constructor_calldata = [
+            ctx.lords.contract_address,
+            ctx.resources.contract_address,
+        ]
+    )
+
+    ctx.exchange = exchange
+
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_check_addr(exchange_factory):
+    print("test_check_addr")
+    ctx = exchange_factory
+    exchange = ctx.exchange
+
+    res = await exchange.get_currency_address().call()
+    print(res.result)
+    assert res.result.address == (ctx.lords.contract_address)
+
+    res = await exchange.get_token_address().call()
+    print(res.result)
+    assert res.result.address == (ctx.resources.contract_address)

--- a/testing/l2/Exchange_ERC20_1155_test.py
+++ b/testing/l2/Exchange_ERC20_1155_test.py
@@ -26,8 +26,8 @@ async def test_check_addr(exchange_factory):
 
     res = await exchange.get_currency_address().call()
     print(res.result)
-    assert res.result.address == (ctx.lords.contract_address)
+    assert res.result.currency_address == (ctx.lords.contract_address)
 
     res = await exchange.get_token_address().call()
     print(res.result)
-    assert res.result.address == (ctx.resources.contract_address)
+    assert res.result.token_address == (ctx.resources.contract_address)

--- a/testing/l2/conftest.py
+++ b/testing/l2/conftest.py
@@ -161,14 +161,14 @@ async def _build_copyable_deployment():
             [contract_address, *uint(amount)],
         )
 
-    lords_approve_ammount = consts.REALM_MINT_PRICE * 3
+    lords_approve_amount = consts.REALM_MINT_PRICE * 3
 
     async def mint_realms(account_name, token):
         await signers[account_name].send_transaction(
             accounts.__dict__[account_name], realms.contract_address, 'publicMint', [*uint(token)]
         )
 
-    await _erc20_approve("user1", realms.contract_address, lords_approve_ammount)
+    await _erc20_approve("user1", realms.contract_address, lords_approve_amount)
     await give_tokens(accounts.user1.contract_address, initial_user_funds)
     await mint_realms("user1", 23)
     await mint_realms("user1", 7225)
@@ -243,6 +243,7 @@ async def ctx_factory(copyable_deployment):
         return SimpleNamespace(
             starknet=Starknet(starknet_state),
             advance_clock=advance_clock,
+            signers=signers,
             consts=consts,
             execute=execute,
             **contracts,

--- a/testing/l2/conftest.py
+++ b/testing/l2/conftest.py
@@ -134,10 +134,10 @@ async def _build_copyable_deployment():
         contract_def=defs.erc1155,
         constructor_calldata=[
             accounts.admin.contract_address, #recipient
-            2, #token_ids_len
-            1, 2,
-            2, #amounts_len
-            100000, 5000
+            5, #token_ids_len
+            1, 2, 3, 4, 5,
+            5, #amounts_len
+            100000, 5000, 10000, 10000, 10000,
         ])
 
     consts = SimpleNamespace(

--- a/testing/l2/conftest.py
+++ b/testing/l2/conftest.py
@@ -137,7 +137,7 @@ async def _build_copyable_deployment():
             2, #token_ids_len
             1, 2,
             2, #amounts_len
-            1000, 5000
+            100000, 5000
         ])
 
     consts = SimpleNamespace(


### PR DESCRIPTION
This is for the proposal outlined in Snapshot: 
https://snapshot.org/#/council.bibliotheca.eth/proposal/0x34a09597e73f3d45c0f2d8d5cac6dfb562add3adddaba72040ac688f8b60f580

Features:

* Buy / Sell across ERC20 / ERC1155 pairs
* One exchange supports all token ids across the ERC1155 contract
* Liquidity provider fees are customisable during deployment
* LP tokens are ERC1155 compliant so they are tradable etc

Considerations:

* `felt` vs `Uint256`. I've gone with Uint256 for all currency-related fields, felt for everything else. 
* The current ERC1155 implementation is not compliant with the ERC1155 spec as it does not support the `safeTransfer` callbacks. Due to this, the exchange contract must have unlimited approval on a token to use it. This is not so desirable from a gas or security perspective. 
* A non-reentrant check should be added to all `@external` methods. 
* ERC2981 compliance has not been added
* Considering squashing this branch when you merge