### PR TITLE
Feat/subtree

### DIFF
--- a/openzeppelin/.gitattributes
+++ b/openzeppelin/.gitattributes
@@ -1,0 +1,1 @@
+*.cairo linguist-language=python

--- a/openzeppelin/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/openzeppelin/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Briefly describe the issue you're experiencing. Tell us what you were trying to do and what happened instead. -->
+
+<!-- Remember, this is not a place to ask for help debugging code. For that, we welcome you in the OpenZeppelin Community Forum: https://forum.openzeppelin.com/. -->
+
+**📝 Details**
+
+<!-- Describe the problem you have been experiencing in more detail. Include as much information as you think is relevant. Keep in mind that transactions can fail for many reasons; context is key here. -->
+
+**🔢 Code to reproduce bug**
+
+<!-- We will be able to better help if you provide a minimal example that triggers the bug. -->

--- a/openzeppelin/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/openzeppelin/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**🧐 Motivation**
+<!-- Is your feature request related to a specific problem? Is it just a crazy idea? Tell us about it! -->
+**📝 Details**
+
+<!-- Describe the problem you have been experiencing in more detail. Include as much information as you think is relevant. Keep in mind that transactions can fail for many reasons; context is key here. -->
+**📝 Details**
+<!-- Please describe your feature request in detail. -->

--- a/openzeppelin/.github/workflows/python-app.yml
+++ b/openzeppelin/.github/workflows/python-app.yml
@@ -1,0 +1,70 @@
+name: Tests and release
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    tags:
+    - "v*"
+  release:
+    types: [published]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest tox cairo-lang
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with tox and pytest
+      run: |
+        tox
+
+  dist:
+    runs-on: ubuntu-latest
+    needs: [test]
+    name: Python sdist/wheel
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - run: python -m pip install -U setuptools
+    - run: python -m pip install -e .[testing]
+    - name: Build package
+      run: tox -e build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist
+
+  dist_upload:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    needs: [dist]
+    name: Upload to PyPi
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: dist
+        path: dist
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_token }}

--- a/openzeppelin/.gitignore
+++ b/openzeppelin/.gitignore
@@ -1,0 +1,131 @@
+artifacts/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/openzeppelin/LICENSE
+++ b/openzeppelin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 OpenZeppelin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openzeppelin/MANIFEST.in
+++ b/openzeppelin/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/ *.cairo

--- a/openzeppelin/README.md
+++ b/openzeppelin/README.md
@@ -1,0 +1,124 @@
+# OpenZeppelin Cairo Contracts
+[![Tests and linter](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/python-app.yml/badge.svg)](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/python-app.yml)
+
+**A library for secure smart contract development** written in Cairo for [StarkNet](https://starkware.co/product/starknet/), a decentralized ZK Rollup.
+
+> ## ⚠️ WARNING! ⚠️
+> This is repo contains highly experimental code.
+> Expect rapid iteration.
+> **Do not use in production.**
+
+## Installation
+
+### First time?
+
+Before installing Cairo on your machine, you need to install `gmp`:
+```bash
+sudo apt install -y libgmp3-dev # linux
+brew install gmp # mac
+```
+> If you have any troubles installing gmp on your Apple M1 computer, [here’s a list of potential solutions](https://github.com/OpenZeppelin/nile/issues/22).
+
+### Set up the project
+Clone the repository
+
+```bash
+git clone git@github.com:OpenZeppelin/cairo-contracts.git
+```
+
+`cd` into it and create a Python virtual environment:
+
+```bash
+cd cairo-contracts
+python3 -m venv env
+source env/bin/activate
+```
+
+Install the [Nile](https://github.com/OpenZeppelin/nile) dev environment and then run `install` to get [the Cairo language](https://www.cairo-lang.org/docs/quickstart.html), a [local network](https://github.com/Shard-Labs/starknet-devnet/), and a [testing framework](https://docs.pytest.org/en/6.2.x/).
+```bash
+pip install cairo-nile
+nile install
+```
+
+## Usage
+
+### Compile the contracts
+```bash
+nile compile --directory openzeppelin
+
+🤖 Compiling all Cairo contracts in the openzeppelin directory
+🔨 Compiling openzeppelin/introspection/ERC165.cairo
+🔨 Compiling openzeppelin/introspection/IERC165.cairo
+🔨 Compiling openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo
+🔨 Compiling openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
+🔨 Compiling openzeppelin/token/erc721/library.cairo
+🔨 Compiling openzeppelin/token/erc721/interfaces/IERC721_Metadata.cairo
+🔨 Compiling openzeppelin/token/erc721/interfaces/IERC721.cairo
+🔨 Compiling openzeppelin/token/erc721/interfaces/IERC721_Receiver.cairo
+🔨 Compiling openzeppelin/token/erc721/utils/ERC721_Holder.cairo
+🔨 Compiling openzeppelin/token/erc20/ERC20_Mintable.cairo
+🔨 Compiling openzeppelin/token/erc20/ERC20.cairo
+🔨 Compiling openzeppelin/token/erc20/library.cairo
+🔨 Compiling openzeppelin/token/erc20/ERC20_Pausable.cairo
+🔨 Compiling openzeppelin/token/erc20/interfaces/IERC20.cairo
+🔨 Compiling openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo
+🔨 Compiling openzeppelin/token/erc721_enumerable/library.cairo
+🔨 Compiling openzeppelin/token/erc721_enumerable/interfaces/IERC721_Enumerable.cairo
+🔨 Compiling openzeppelin/security/pausable.cairo
+🔨 Compiling openzeppelin/security/safemath.cairo
+🔨 Compiling openzeppelin/security/initializable.cairo
+🔨 Compiling openzeppelin/access/ownable.cairo
+🔨 Compiling openzeppelin/account/IAccount.cairo
+🔨 Compiling openzeppelin/account/Account.cairo
+🔨 Compiling openzeppelin/account/AddressRegistry.cairo
+🔨 Compiling openzeppelin/utils/constants.cairo
+✅ Done
+```
+
+### Run tests
+
+Run tests using [tox](https://tox.wiki/en/latest/), tox automatically creates an isolated testing environment:
+
+```bash
+tox
+
+====================== test session starts ======================
+platform linux -- Python 3.7.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
+rootdir: /home/readme/cairo-contracts
+plugins: asyncio-0.16.0, web3-5.24.0, typeguard-2.13.0
+collected 19 items                                                                                               
+
+tests/test_Account.py ....                                 [ 21%]
+tests/test_AddressRegistry.py ..                           [ 31%]
+tests/test_ERC20.py ..........                             [ 84%]
+tests/test_Initializable.py .                              [ 89%]
+tests/test_Ownable.py ..                                   [100%]
+```
+
+## Learn
+
+### Contract documentation
+* [Account](docs/Account.md)
+* [ERC20](docs/ERC20.md)
+* [ERC721](docs/ERC721.md)
+* [Contract extensibility pattern](docs/Extensibility.md)
+* [Proxies and upgrades](docs/Proxies.md)
+* [Utilities](docs/Utilities.md)
+### Cairo
+* [StarkNet official documentation](https://www.cairo-lang.org/docs/hello_starknet/index.html#hello-starknet)
+* [Cairo language documentation](https://www.cairo-lang.org/docs/hello_cairo/index.html#hello-cairo)
+* Perama's [Cairo by example](https://perama-v.github.io/cairo/by-example/)
+* [Cairo 101 workshops](https://www.youtube.com/playlist?list=PLcIyXLwiPilV5RBZj43AX1FY4FJMWHFTY)
+### Nile
+* [Getting started with StarkNet using Nile](https://medium.com/coinmonks/starknet-tutorial-for-beginners-using-nile-6af9c2270c15)
+* [How to manage smart contract deployments with Nile](https://medium.com/@martriay/manage-your-starknet-deployments-with-nile-%EF%B8%8F-e849d40546dd)
+
+## Security
+
+This project is still in a very early and experimental phase. It has never been audited nor thoroughly reviewed for security vulnerabilities. Do not use in production.
+
+Please report any security issues you find to security@openzeppelin.org.
+
+## License
+
+OpenZeppelin Cairo Contracts is released under the [MIT License](LICENSE).

--- a/openzeppelin/docs/Account.md
+++ b/openzeppelin/docs/Account.md
@@ -1,0 +1,349 @@
+# Accounts
+Unlike Ethereum where accounts are directly derived from a private key, there's no native account concept on StarkNet.
+
+Instead, signature validation has to be done at the contract level. To relieve smart contract applications such as ERC20 tokens or exchanges from this responsibility, we make use of Account contracts to deal with transaction authentication.
+
+A more detailed writeup on the topic can be found on [Perama's blogpost](https://perama-v.github.io/cairo/account-abstraction/).
+
+## Table of Contents
+
+* [Quickstart](#quickstart)
+* [Standard Interface](#standard-interface)
+* [Keys, signatures and signers](#keys--signatures-and-signers)
+    + [Signer utility](#signer-utility)
+* [Message format](#message-format)
+* [MultiCall](#-multicall-)
+* [API Specification](#api-specification)
+    - [`get_public_key`](#-get-public-key-)
+    - [`get_nonce`](#-get-nonce-)
+    - [`set_public_key`](#-set-public-key-)
+    - [`is_valid_signature`](#-is-valid-signature-)
+    - [`__execute__`](#-__execute__-)
+* [Account differentiation with ERC165](#account-differentiation-with-erc165)
+* [Extending the Account contract](#extending-the-account-contract)
+* [L1 escape hatch mechanism](#l1-escape-hatch-mechanism)
+* [Paying for gas](#paying-for-gas)
+
+## Quickstart
+
+The general workflow is: 
+1. Account contract is deployed to StarkNet
+2. Signed transactions can now be sent to the Account contract which validates and executes them
+
+In Python, this would look as follows:
+
+```python
+from starkware.starknet.testing.starknet import Starknet
+signer = Signer(123456789987654321)
+starknet = await Starknet.empty()
+
+# 1. Deploy Account
+account = await starknet.deploy(
+    "contracts/Account.cairo",
+    constructor_calldata=[signer.public_key]
+)
+
+# 2. Send transaction through Account
+await signer.send_transaction(account, some_contract_address, 'some_function', [some_parameter])
+```
+
+## Standard Interface
+
+The [`IAccount.cairo`](https://github.com/OpenZeppelin/cairo-contracts/blob/8739a1c2c28b1fe0b6ed7a10a66aa7171da41326/contracts/IAccount.cairo) contract interface contains the standard account interface proposed in [#41](https://github.com/OpenZeppelin/cairo-contracts/discussions/41) and adopted by OpenZeppelin and Argent. It implements [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and it is agnostic of signature validation and nonce management strategies.
+
+```c#
+@contract_interface
+namespace IAccount:
+    #
+    # Getters
+    #
+
+    func get_nonce() -> (res : felt):
+    end
+
+    #
+    # Business logic
+    #
+
+    func is_valid_signature(
+            hash: felt,
+            signature_len: felt,
+            signature: felt*
+        ):
+    end
+
+    func __execute__(
+            call_array_len: felt,
+            call_array: AccountCallArray*,
+            calldata_len: felt,
+            calldata: felt*,
+            nonce: felt
+        ) -> (response_len: felt, response: felt*):
+    end
+end
+```
+
+## Keys, signatures and signers
+
+While the interface is agnostic of signature validation schemes, this implementation assumes there's a public-private key pair controlling the Account. That's why the `constructor` function expects a `public_key` parameter to set it. Since there's also a `set_public_key()` method, accounts can be effectively transferred.
+
+Note that although the current implementation works only with StarkKeys, support for Ethereum's ECDSA algorithm will be added in the future.
+
+### Signer utility
+
+[Signer.py](https://github.com/OpenZeppelin/cairo-contracts/blob/8739a1c2c28b1fe0b6ed7a10a66aa7171da41326/tests/utils/Signer.py) is used to perform transactions on a given Account, crafting the tx and managing nonces.
+
+It exposes three functions:
+
+- `def sign(message_hash)` receives a hash and returns a signed message of it
+- `def send_transaction(account, to, selector_name, calldata, nonce=None, max_fee=0)` returns a future of a signed transaction, ready to be sent.
+- `def send_transactions(account, calls, nonce=None, max_fee=0)` returns a future of batched signed transactions, ready to be sent.
+
+To use Signer, pass a private key when instantiating the class:
+
+```python
+from utils.Signer import Signer
+
+PRIVATE_KEY = 123456789987654321
+signer = Signer(PRIVATE_KEY)
+```
+
+Then send single transactions with the `send_transaction` method.
+
+```python
+await signer.send_transaction(account, contract_address, 'method_name', [])
+```
+
+If utilizing multicall, send multiple transactions with the `send_transactions` method.
+
+```python
+    await signer.send_transactions(
+        account,
+        [
+            (contract_address, 'method_name', [param1, param2]),
+            (contract_address, 'another_method', [])
+        ]
+    )
+```
+
+
+## Call and MultiCall format
+
+The idea is for all user intent to be encoded into a `Call` representing a smart contract call. If the user wants to send multiple messages in a single transaction, these `Call`s are bundled into a `MultiCall`. It should be noted that every transaction utilizes multicall. A single `Call`, however, is treated as a bundle of one.
+
+A single `Call` is structured as follows:
+
+```c#
+struct Call:
+    member to: felt
+    member selector: felt
+    member calldata_len: felt
+    member calldata: felt*
+end
+```
+
+Where:
+
+- `to` is the address of the target contract of the message
+- `selector` is the selector of the function to be called on the target contract
+- `calldata_len` is the number of calldata parameters
+- `calldata` is an array representing the function parameters
+
+`MultiCall` is structured as:
+
+```c#
+struct MultiCall:
+    member account: felt
+    member calls_len: felt
+    member calls: Call*
+    member nonce: felt
+    member max_fee: felt
+    member version: felt
+end
+```
+
+Where:
+
+- `account` is the Account contract address. It is included to prevent transaction replays in case there's another Account contract controlled by the same public keys
+- `calls_len` is the number of calls bundled into the transaction
+- `calls` is an array representing each `Call`
+- `nonce` is an unique identifier of this message to prevent transaction replays. Current implementation requires nonces to be incremental
+- `max_fee` is the maximum fee a user will pay
+- `version` is a fixed number which is used to invalidate old transactions
+
+This `MultiCall` message is built within the `__execute__` method which has the following interface:
+```cairo
+func __execute__(
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata_len: felt,
+        calldata: felt*,
+        nonce: felt
+    ) -> (response_len: felt, response: felt*):
+end
+```
+
+Where:
+
+- `call_array_len` is the number of calls
+- `call_array` is an array representing each `Call`
+- `calldata_len` is the number of calldata parameters
+- `calldata` is an array representing the function parameters 
+- `nonce` is an unique identifier of this message to prevent transaction replays. Current implementation requires nonces to be incremental
+
+`__execute__` acts as a single entrypoint for all user interaction with any contract, including managing the account contract itself. That's why if you want to change the public key controlling the Account, you would send a transaction targeting the very Account contract:
+
+```python
+await signer.send_transaction(account, account.contract_address, 'set_public_key', [NEW_KEY])
+```
+
+Note that Signer's `send_transaction` and `send_transactions` call `__execute__` under the hood.
+
+Or if you want to update the Account's L1 address on the `AccountRegistry` contract, you would 
+
+```python
+await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [NEW_ADDRESS])
+```
+
+You can read more about how messages are structured and hashed in the [Account message scheme  discussion](https://github.com/OpenZeppelin/cairo-contracts/discussions/24). For more information on the design choices and implementation of multicall, you can read the [How should Account multicall work discussion](https://github.com/OpenZeppelin/cairo-contracts/discussions/27).
+
+> Note that the scheme of building multicall transactions within the `__execute__` method will change once StarkNet allows for pointers in struct arrays. In which case, multiple transactions can be passed to (as opposed to built within) `__execute__`.
+
+
+## API Specification
+
+This in a nutshell is the Account contract public API:
+
+```cairo
+func get_public_key() -> (res: felt):
+end
+
+func get_nonce() -> (res: felt):
+end
+
+func set_public_key(new_public_key: felt):
+end
+
+func is_valid_signature(hash: felt,
+        signature_len: felt,
+        signature: felt*
+    ):
+end
+
+func __execute__(
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata_len: felt,
+        calldata: felt*,
+        nonce: felt
+    ) -> (response_len: felt, response: felt*):
+end
+```
+
+#### `get_public_key`
+
+Returns the public key associated with the Account contract.
+
+##### Parameters:
+
+None.
+
+##### Returns:
+```
+public_key: felt
+```
+
+#### `get_nonce`
+
+Returns the current transaction nonce for the Account.
+
+##### Parameters:
+
+None.
+
+##### Returns:
+
+```
+nonce: felt
+```
+
+#### `set_public_key`
+
+Sets the public key that will control this Account. It can be used to rotate keys for security, change them in case of compromised keys or even transferring ownership of the account.
+
+##### Parameters:
+```
+public_key: felt
+```
+
+##### Returns:
+
+None.
+
+#### `is_valid_signature`
+
+This function is inspired by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) and checks whether a given signature is valid, otherwise it reverts.
+
+##### Parameters:
+```
+hash: felt
+signature_len: felt
+signature: felt*
+```
+
+##### Returns:
+
+None.
+
+#### `__execute__`
+
+This is the only external entrypoint to interact with the Account contract. It:
+
+1. Takes the input and builds a [Multicall](#message-format) message with it
+2. Validates the transaction signature matches the message (including the nonce)
+3. Increments the nonce
+4. Calls the target contract with the intended function selector and calldata parameters
+5. Forwards the contract call response data as return value
+
+##### Parameters:
+```
+call_array_len: felt
+call_array: AccountCallArray*
+calldata_len: felt
+calldata: felt*
+nonce: felt
+```
+
+> Note that the current signature scheme expects a 2-element array like `[sig_r, sig_s]`.
+
+
+##### Returns:
+```
+response_len: felt
+response: felt*
+```
+
+## Account differentiation with ERC165
+
+Certain contracts like ERC721 require a means to differentiate between account contracts and non-account contracts. For a contract to declare itself as an account, it should implement [ERC165](https://eips.ethereum.org/EIPS/eip-165) as proposed in [#100](https://github.com/OpenZeppelin/cairo-contracts/discussions/100). To be in compliance with ERC165 specifications, the idea is to calculate the XOR of `IAccount`'s EVM selectors (not StarkNet selectors). The resulting magic value of `IAccount` is 0x50b70dcb.
+
+Our ERC165 integration on StarkNet is inspired by OpenZeppelin's Solidity implementation of [ERC165Storage](https://docs.openzeppelin.com/contracts/4.x/api/utils#ERC165Storage) which stores the interfaces that the implementing contract supports. In the case of account contracts, querying `supportsInterface` of an account's address with the `IAccount` magic value should return [`TRUE`](../openzeppelin/utils/constants.cairo) (a constant variable representing `1` in Cairo).
+
+## Extending the Account contract
+
+Account contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite methods from the Account library and incorporate the extended logic thereafter.
+
+Currently, there's only a single library/preset Account scheme, but we're looking for feedback and new presets to emerge. Some new validation schemes to look out for in the future:
+- multisig
+- guardian logic like in [Argent's account](https://github.com/argentlabs/argent-contracts-starknet/blob/de5654555309fa76160ba3d7393d32d2b12e7349/contracts/ArgentAccount.cairo)
+- [Ethereum signatures](https://github.com/OpenZeppelin/cairo-contracts/issues/161)
+
+
+## L1 escape hatch mechanism
+
+*[unknown, to be defined]*
+
+
+## Paying for gas
+
+*[unknown, to be defined]*

--- a/openzeppelin/docs/ERC20.md
+++ b/openzeppelin/docs/ERC20.md
@@ -1,0 +1,386 @@
+# ERC20
+
+The ERC20 token standard is a specification for [fungible tokens](https://docs.openzeppelin.com/contracts/4.x/tokens#different-kinds-of-tokens), a type of token where all the units are exactly equal to each other. The `ERC20.cairo` contract implements an approximation of [EIP-20](https://eips.ethereum.org/EIPS/eip-20) in Cairo for StarkNet.
+
+## Table of Contents
+
+- [Interface](#interface)
+  * [ERC20 compatibility](#erc20-compatibility)
+- [Usage](#usage)
+- [Extensibility](#extensibility)
+- [Presets](#presets)
+  * [ERC20 (basic)](#erc20-(basic))
+  * [ERC20_Mintable](#erc20_mintable)
+  * [ERC20_Pausable](#erc20_pausable)
+  * [ERC20_Upgradeable](#erc20_upgradeable)
+- [API Specification](#api-specification)
+  * [Methods](#-methods-)
+    * [`name`](#-name-)
+    * [`symbol`](#-symbol-)
+    * [`decimals`](#-decimals-)
+    * [`totalSupply`](#-total-supply-)
+    * [`balanceOf`](#-balance-of-)
+    * [`allowance`](#-allowance-)
+    * [`transfer`](#-transfer-)
+    * [`transferFrom`](#-transferfrom-)
+    * [`approve`](#-approve-)
+  * [Events](#-events-)
+    * [`Transfer (event)`](#-transfer-(event)-)
+    * [`Approval (event)`](#-approval-(event)-)
+
+## Interface
+
+```jsx
+@contract_interface
+namespace IERC20:
+    func name() -> (name: felt):
+    end
+
+    func symbol() -> (symbol: felt):
+    end
+
+    func decimals() -> (decimals: felt):
+    end
+
+    func totalSupply() -> (totalSupply: Uint256):
+    end
+
+    func balanceOf(account: felt) -> (balance: Uint256):
+    end
+
+    func allowance(owner: felt, spender: felt) -> (remaining: Uint256):
+    end
+
+    func transfer(recipient: felt, amount: Uint256) -> (success: felt):
+    end
+
+    func transferFrom(
+            sender: felt, 
+            recipient: felt, 
+            amount: Uint256
+        ) -> (success: felt):
+    end
+
+    func approve(spender: felt, amount: Uint256) -> (success: felt):
+    end
+end
+```
+
+### ERC20 compatibility
+
+Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC20 standard, in the following ways:
+
+- it uses Cairo's `uint256` instead of `felt`
+- it returns `TRUE` (a constant representing `1`) as success
+- it accepts a `felt` argument for `decimals` in the constructor calldata with a max value of 2^8 (imitating `uint8` type)
+- it makes use of Cairo's short strings to simulate `name` and `symbol`
+
+But some differences can still be found, such as:
+
+- `transfer`, `transferFrom` and `approve` will never return anything different from `TRUE` because they will revert on any error
+- function selectors are calculated differently between [Cairo](https://github.com/starkware-libs/cairo-lang/blob/7712b21fc3b1cb02321a58d0c0579f5370147a8b/src/starkware/starknet/public/abi.py#L25) and [Solidity](https://solidity-by-example.org/function-selector/)
+
+## Usage
+
+Use cases go from medium of exchange currency to voting rights, staking, and more.
+
+Considering that the constructor method looks like this:
+
+```python
+func constructor(
+    name: felt,               # Token name as Cairo short string
+    symbol: felt,             # Token symbol as Cairo short string
+    decimals: felt            # Token decimals (usually 18)
+    initial_supply: Uint256,  # Amount to be minted
+    recipient: felt           # Address where to send initial supply to
+):
+```
+
+To create a token you need to deploy it like this:
+
+```python
+erc20 = await starknet.deploy(
+    "contracts/token/ERC20.cairo",
+    constructor_calldata=[
+        str_to_felt("Token"),     # name
+        str_to_felt("TKN"),       # symbol
+        18,                       # decimals
+        (1000, 0),                # initial supply
+        account.contract_address  # recipient
+    ]
+)
+```
+
+As most StarkNet contracts, it expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`). This is why we need an Account contract to interact with it. For example:
+
+```python
+signer = Signer(PRIVATE_KEY)
+amount = uint(100)
+
+account = await starknet.deploy(
+    "contracts/Account.cairo",
+    constructor_calldata=[signer.public_key]
+)
+
+await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient_address, *amount])
+```
+
+## Extensibility
+
+ERC20 contracts can be extended by following the [extensibility pattern](../docs/Extensibility.md#the-pattern). The basic idea behind integrating the pattern is to import the requisite ERC20 methods from the ERC20 library and incorporate the extended logic thereafter. For example, let's say you wanted to implement a pausing mechanism. The contract should first import the ERC20 methods and the extended logic from the [pausable library](../openzeppelin/security/pausable.cairo) i.e. `Pausable_pause`, `Pausable_unpause`. Next, the contract should expose the methods with the extended logic therein like this:
+
+```python
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    Pausable_when_not_paused()            # imported extended logic
+    ERC20_transfer(recipient, amount)     # imported library method
+    return (TRUE)
+end
+```
+
+Note that extensibility does not have to be only library-based like in the above example. For instance, an ERC20 contract with a pausing mechanism can define the pausing methods directly in the contract or even import the `pausable` methods from the library and tailor them further.
+
+Some other ways to extend ERC20 contracts may include:
+- Implementing a minting mechanism
+- Creating a timelock
+- Adding roles such as owner or minter
+
+For full examples of the extensibility pattern being used in ERC20 contracts, see [Presets](#presets).
+
+## Presets
+
+The following contract presets are ready to deploy and can be used as-is for quick prototyping and testing. Each preset mints an initial supply which is especially necessary for presets that do not expose a `mint` method.
+
+### ERC20 (basic)
+
+The [`ERC20`](../openzeppelin/token/erc20/ERC20.cairo) preset offers a quick and easy setup for deploying a basic ERC20 token.
+
+### ERC20_Mintable
+
+The [`ERC20_Mintable`](../openzeppelin/token/erc20/ERC20_Mintable.cairo) preset allows the contract owner to mint new tokens. 
+
+### ERC20_Pausable
+
+The [`ERC20_Pausable`](../openzeppelin/token/erc20/ERC20_Pausable.cairo) preset allows the contract owner to pause/unpause all state-modifying methods i.e. `transfer`, `approve`, etc. This preset proves useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch for freezing all token transfers in the event of a large bug.
+
+### ERC20_Upgradeable
+
+The [`ERC20_Upgradeable`](../openzeppelin/token/erc20/ERC20_Upgradeable.cairo) preset allows the contract owner to upgrade a contract by deploying a new ERC20 implementation contract while also maintaing the contract's state. This preset proves useful for scenarios such as eliminating bugs and adding new features. For more on upgradeability, see [Contract upgrades](../docs/Proxy.md#contract-upgrades).
+
+## API Specification
+
+### Methods
+
+```jsx
+func name() -> (name: felt):
+end
+
+func symbol() -> (symbol: felt):
+end
+
+func decimals() -> (decimals: felt):
+end
+
+func totalSupply() -> (totalSupply: Uint256):
+end
+
+func balanceOf(account: felt) -> (balance: Uint256):
+end
+
+func allowance(owner: felt, spender: felt) -> (remaining: Uint256):
+end
+
+func transfer(recipient: felt, amount: Uint256) -> (success: felt):
+end
+
+func transferFrom(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (success: felt):
+end
+
+func approve(spender: felt, amount: Uint256) -> (success: felt):
+end
+```
+
+#### `name`
+
+Returns the name of the token.
+
+Parameters: None.
+
+Returns:
+
+```jsx
+name: felt
+```
+
+#### `symbol`
+
+Returns the ticker symbol of the token.
+
+Parameters: None.
+
+Returns:
+
+```jsx
+symbol: felt
+```
+
+#### `decimals`
+
+Returns the number of decimals the token uses - e.g. 8 means to divide the token amount by 100000000 to get its user representation.
+
+Parameters: None.
+
+Returns:
+
+```jsx
+decimals: felt
+```
+
+#### `totalSupply`
+
+Returns the amount of tokens in existence.
+
+Parameters: None.
+
+Returns:
+
+```jsx
+totalSupply: Uint256
+```
+
+#### `balanceOf`
+
+Returns the amount of tokens owned by `account`.
+
+Parameters:
+
+```jsx
+account: felt
+```
+
+Returns:
+
+```jsx
+balance: Uint256
+```
+
+#### `allowance`
+
+Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner` through `transferFrom`. This is zero by default.
+
+This value changes when `approve` or `transferFrom` are called.
+
+Parameters:
+
+```jsx
+owner: felt
+spender: felt
+```
+
+Returns:
+
+```jsx
+remaining: Uint256
+```
+
+#### `transfer`
+
+Moves `amount` tokens from the caller’s account to `recipient`. It returns `1` representing a bool if it succeeds.
+
+Emits a [Transfer](#-transfer-(event)-) event.
+
+Parameters:
+
+```jsx
+recipient: felt
+amount: Uint256
+```
+
+Returns:
+
+```jsx
+success: felt
+```
+
+#### `transferFrom`
+
+Moves `amount` tokens from `sender` to `recipient` using the allowance mechanism. `amount` is then deducted from the caller’s allowance. It returns `1` representing a bool if it succeeds.
+
+Emits a [Transfer](#-transfer-(event)-) event.
+
+Parameters:
+
+```jsx
+sender: felt
+recipient: felt
+amount: Uint256
+```
+
+Returns:
+
+```jsx
+success: felt
+```
+
+#### `approve`
+
+Sets `amount` as the allowance of `spender` over the caller’s tokens. It returns `1` representing a bool if it succeeds.
+
+Emits an [Approval](#-approval-(event)-) event.
+
+Parameters:
+
+```jsx
+spender: felt
+amount: Uint256
+```
+
+Returns:
+
+```jsx
+success: felt
+```
+
+### Events
+
+```jsx
+func Transfer(from_: felt, to: felt, value: Uint256):
+end
+
+func Approval(owner: felt, spender: felt, value: Uint256):
+end
+```
+
+#### `Transfer (event)`
+
+Emitted when `value` tokens are moved from one account (`from_`) to another (`to`). 
+
+Note that `value` may be zero.
+
+Parameters:
+
+```jsx
+from_: felt
+to: felt
+value: Uint256
+```
+
+#### `Approval (event)`
+
+Emitted when the allowance of a `spender` for an `owner` is set by a call to [approve](#-approve-). `value` is the new allowance.
+
+Parameters:
+
+```jsx
+owner: felt
+spender: felt
+value: Uint256
+```

--- a/openzeppelin/docs/ERC721.md
+++ b/openzeppelin/docs/ERC721.md
@@ -1,0 +1,749 @@
+# ERC721
+
+The ERC721 token standard is a specification for [non-fungible tokens](https://docs.openzeppelin.com/contracts/4.x/tokens#different-kinds-of-tokens), or more colloquially: NFTs. The `ERC721.cairo` contract implements an approximation of [EIP-721](https://eips.ethereum.org/EIPS/eip-721) in Cairo for StarkNet.
+
+## Table of Contents
+
+- [IERC721](#ierc721)
+- [ERC721 Compatibility](#erc721-compatibility)
+- [Usage](#usage)
+  *  [Token Transfers](#token-transfers)
+  *  [Interpreting ERC721 URIs](#interpreting-erc721-uris)
+  *  [ERC721Received](#erc721received)
+      -  [IERC721_Receiver](#ierc721_receiver)
+  *  [Supporting Interfaces](#supporting-interfaces)
+  *  [Ready-to-Use Presets](#ready-to-use-presets)
+- [Extensibility](#extensibility)
+- [Presets](#presets)
+  *  [ERC721_Mintable_Burnable](#erc721_mintable_burnable)
+  *  [ERC721_Mintable_Pausable](#erc721_mintable_pausable)
+  *  [ERC721_Enumerable_Mintable_Burnable](#erc721_enumerable_mintable_burnable)
+      -  [IERC721_Enumerable](#ierc721_enumerable)
+  *  [ERC721_Metadata](#erc721_metadata)
+      -  [IERC721_Metadata](#ierc721_metadata)
+- [Utilities](#utilities)
+  *  [ERC721_Holder](#erc721_holder)
+- [API Specification](#api-specification)
+  * [`IERC721`](#ierc721-api)
+    - [`balanceOf`](#-balanceOf-)
+    - [`ownerOf`](#-ownerOf-)
+    - [`safeTransferFrom`](#-safeTransferFrom-)
+    - [`transferFrom`](#-transferFrom-)
+    - [`approve`](#-approve-)
+    - [`setApprovalForAll`](#-setApprovalForAll-)
+    - [`getApproved`](#-getApproved-)
+    - [`isApprovedForAll`](#-isApprovedForAll-)
+  * [Events](#events)
+    - [`Approval (event)`](#-Approval-(event)-)
+    - [`ApprovalForAll (event)`](#-ApprovalForAll-(event)-)
+    - [`Transfer (event)`](#-Transfer-(event)-)
+  * [`IERC721_Metadata`](#ierc721_metadata)
+    - [`name`](#-name-)
+    - [`symbol`](#-symbol-)
+    - [`tokenURI`](#-tokenURI-)
+  * [`IERC721_Enumerable`](#ierc721_enumerable)
+    - [`totalSupply`](#-totalSupply-)
+    - [`tokenByIndex`](#-tokenByIndex-)
+    - [`tokenOfOwnerByIndex`](#-tokenOfOwnerByIndex-)
+  * [`IERC721_Receiver`](#ierc721_receiver)
+    - [`onERC721Received`](#-onERC721Received-)
+
+- [ERC165](#erc165)
+  * [IERC165](#ierc165)
+  * [ERC165 API Specification](#erc165-api-specification)
+    - [`IERC165`](#ierc165)
+      - [`supportsInterface`](#-supportsInterface-)
+
+
+## IERC721
+
+```jsx
+@contract_interface
+namespace IERC721:
+    func balanceOf(owner: felt) -> (balance: Uint256):
+    end
+
+    func ownerOf(tokenId: Uint256) -> (owner: felt):
+    end
+
+    func safeTransferFrom(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256, 
+        data_len: felt,
+        data: felt*
+    ):
+
+    func transferFrom(from_: felt, to: felt, tokenId: Uint256):
+    end
+
+    func approve(approved: felt, tokenId: Uint256):
+    end
+
+    func setApprovalForAll(operator: felt, approved: felt):
+    end
+
+    func getApproved(tokenId: Uint256) -> (approved: felt):
+    end
+
+    func isApprovedForAll(owner: felt, operator: felt) -> (isApproved: felt):
+    end
+
+    --------------- IERC165 ---------------
+
+    func supportsInterface(interfaceId: felt) -> (success: felt):
+    end
+end
+```
+
+### ERC721 Compatibility
+
+Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC721 standard in the following ways:
+
+- it uses Cairo's `uint256` instead of `felt`
+- it returns `TRUE` (a constant representing `1`) as success
+- it makes use of Cairo's short strings to simulate `name` and `symbol`
+
+But some differences can still be found, such as:
+
+- `tokenURI` returns a felt representation of the queried token's URI. The EIP721 standard, however, states that the return value should be of type string. If a token's URI is not set, the returned value is `0`. Note that URIs cannot exceed 31 characters. See [Interpreting ERC721 URIs](#interpreting-erc721-uris) 
+- `interface_id`s are hardcoded and initialized by the constructor. The hardcoded values derive from Solidity's selector calculations. See [Supporting Interfaces](#supporting-interfaces)
+- `safeTransferFrom` can only be expressed as a single function in Cairo as opposed to the two functions declared in EIP721. The difference between both functions consists of accepting `data` as an argument. Because function overloading is currently not possible in Cairo, `safeTransferFrom` by default accepts the `data` argument. If `data` is not used, simply insert `0`.
+- `safeTransferFrom` is specified such that the optional `data` argument should be of type bytes. In Solidity, this means a dynamically-sized array. To be as close as possible to the standard, it accepts a dynamic array of felts. In Cairo, arrays are expressed with the array length preceding the actual array; hence, the method accepts `data_len` and `data` respectively as types `felt` and `felt*`
+- `ERC165_register_interface` allows contracts to set and communicate which interfaces they support. This follows OpenZeppelin's [ERC165Storage](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/introspection/ERC165Storage.sol)
+- `IERC721_Receiver` compliant contracts (`ERC721_Holder`) return a hardcoded selector id according to EVM selectors, since selectors are calculated differently in Cairo. This is in line with the ERC165 interfaces design choice towards EVM compatibility
+
+- `IERC721_Receiver` compliant contracts (`ERC721_Holder`) must support ERC165 by registering the `IERC721_Receiver` selector id in its constructor and exposing the `supportsInterface` method. In doing so, recipient contracts (both accounts and non-accounts) can be verified that they support ERC721 transfers
+
+- `ERC721_Enumerable` tracks the total number of tokens with the `all_tokens` and `all_tokens_len` storage variables mimicking the array of the Solidity implementation.
+
+## Usage
+
+Use cases go from artwork, digital collectibles, physical property, and many more.
+
+To show a standard use case, we'll use the `ERC721_Mintable` preset which allows for only the owner to `mint` and `burn` tokens. To create a token you need to first deploy both Account and ERC721 contracts respectively. As most StarkNet contracts, ERC721 expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`). This is why we need an Account contract to interact with it.
+
+Considering that the ERC721 constructor method looks like this:
+
+```python
+func constructor(
+    name: felt,          # Token name as Cairo short string
+    symbol: felt,        # Token symbol as Cairo short string
+    owner: felt          # Address designated as the contract owner
+):
+```
+
+Deployment of both contracts looks like this:
+
+```python
+account = await starknet.deploy(
+    "contracts/Account.cairo",
+    constructor_calldata=[signer.public_key]
+)
+
+erc721 = await starknet.deploy(
+    "contracts/token/ERC721_Mintable.cairo",
+    constructor_calldata=[
+        str_to_felt("Token"),                       # name
+        str_to_felt("TKN"),                         # symbol
+        account.contract_address                    # owner
+    ]
+)
+```
+
+To mint a non-fungible token, send a transaction like this:
+
+```python
+signer = Signer(PRIVATE_KEY)
+tokenId = uint(1)
+
+await signer.send_transaction(
+    account, erc721.contract_address, 'mint', [
+        recipient_address, 
+        *tokenId
+    ]
+)
+```
+
+### Token Transfers
+
+EIP721 discourages the use of `transferFrom` and favors `safeTransferFrom` in regard to token transfers. The safe function adds the following conditional logic:
+1. if the calling address is an account contract, the token transfer will behave as if `transferFrom` was called
+2. if the calling address is not an account contract, the safe function will check that the contract supports ERC721 tokens
+
+The current implementation of `safeTansferFrom` checks for `onERC721Received` and requires that the recipient contract supports ERC165 and exposes the `supportsInterface` method. See [ERC721Received](#erc721received)
+
+Please be aware that transferring tokens with `transferFrom` to a contract that does not support ERC721 can result in lost tokens forever. 
+
+### Interpreting ERC721 URIs
+Token URIs in Cairo are stored as single field elements. Each field element equates to 252-bits (or  31.5 bytes) which means that a token's URI can be no longer than 31 characters.
+> Note that storing the URI as an array of felts was considered to accommodate larger strings. While this approach is more flexible regarding URIs, a returned array further deviates from the standard set in [EIP721](https://eips.ethereum.org/EIPS/eip-721). Therefore, this library's ERC721 implementation sets URIs as a single field element.
+
+The `utils.py` module includes utility methods for converting to/from Cairo field elements. To properly interpret a URI from ERC721, simply trim the null bytes and decode the remaining bits as an ASCII string. For example:
+
+```python
+# HELPER METHODS
+def str_to_felt(text):
+    b_text = bytes(text, 'ascii')
+    return int.from_bytes(b_text, "big")
+
+def felt_to_str(felt):
+    b_felt = felt.to_bytes(31, "big")
+    return b_felt.decode()
+
+token_id = uint(1)
+sample_uri = str_to_felt('mock://mytoken')
+
+await signer.send_transaction(
+    account, erc721.contract_address, 'setTokenURI', [
+        *token_id, sample_uri]
+)
+
+felt_uri = await erc721.tokenURI(first_token_id).call()
+string_uri = felt_to_str(felt_uri)
+```
+
+### ERC721Received
+
+In order to be sure a contract can safely accept ERC721 tokens, said contract must implement the `ERC721_Receiver` interface (as expressed in the EIP721 specification). Methods such as `safeTransferFrom` and `safeMint` call the recipient contract's `onERC721Received` method. If the contract fails to return the correct magic value, the transaction fails. 
+
+StarkNet contracts that support safe transfers, however, must also support ERC165 and include `supportsInterface` as proposed in [#100](https://github.com/OpenZeppelin/cairo-contracts/discussions/100). `safeTransferFrom` requires a means of differentiating between account and non-account contracts. Currently, StarkNet does not support error handling from the contract level;
+therefore, the current ERC721 implementation requires that all contracts that support safe ERC721 transfers (both accounts and non-accounts) include the `supportsInterface` method. Further, `supportsInterface` should return `TRUE` if the recipient contract supports the `IERC721_Receiver` magic value `0x150b7a02` (which invokes `onERC721Received`). If the recipient contract supports the `IAccount` magic value `0x50b70dcb`, `supportsInterface` should return `TRUE`. Otherwise, `safeTransferFrom` should fail.
+
+#### IERC721_Receiver
+
+Interface for any contract that wants to support safeTransfers from ERC721 asset contracts.
+
+```jsx
+@contract_interface
+namespace IERC721_Receiver:
+    func onERC721Received(
+        operator: felt,
+        from_: felt,
+        tokenId: Uint256,
+        data_len: felt
+        data: felt*
+    ) -> (selector: felt):
+    end
+end
+```
+
+### Supporting Interfaces 
+
+In order to ensure EVM/StarkNet compatibility, this ERC721 implementation does not calculate interface identifiers. Instead, the interface IDs are hardcoded from their EVM calculations. On the EVM, the interface ID is calculated from the selector's first four bytes of the hash of the function's signature while Cairo selectors are 252 bytes long. Due to this difference, hardcoding EVM's already-calculated interface IDs is the most consistent approach to both follow the EIP165 standard and EVM compatibility.
+
+Further, this implementation stores supported interfaces in a mapping (similar to OpenZeppelin's [ERC165Storage](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/introspection/ERC165Storage.sol)).
+
+### Ready-to-Use Presets 
+
+ERC721 presets have been created to allow for quick deployments as-is. To be as explicit as possible, each preset includes the additional features they offer in the contract name. For example:
+-  `ERC721_Mintable_Burnable` includes `mint` and `burn`
+-  `ERC721_Mintable_Pausable` includes `mint`, `pause`, and `unpause`
+-  `ERC721_Enumerable_Mintable_Burnable` includes `mint`, `burn`, and [IERC721_Enumerable](##ierc721_enumerable) methods
+
+Ready-to-use presets are a great option for testing and prototyping. See [Presets](#presets).
+
+## Extensibility
+
+Following the [contracts extensibility pattern](https://community.starknet.io/t/contract-extensibility-pattern/210), this implementation is set up to include all ERC721 storage and function logic within the `ERC721_base.cairo` library. Library methods with the prefix `ERC721_` must be imported in the smart contract and inserted into an `external` method with the requisite name. This is already done in the [preset contracts](#presets); however, additional functionality can be added. For instance, you could:
+- Implement a pausing mechanism
+- Add roles such as _owner_ or _minter_
+- Modify the `transferFrom` function to mimic the [`_beforeTokenTransfer` and `_afterTokenTransfer` hooks](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L335)
+
+Just be sure that the exposed `external` methods invoke their imported function logic a la `approve` invokes `ERC721_approve`. As an example, see below.
+
+```python
+from contracts.token.ERC721_base import ERC721_approve
+
+@external
+func approve{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    ERC721_approve(to, tokenId)
+    return()
+end
+
+```
+
+## Presets
+
+The following contract presets are ready to deploy and can be used as-is for quick prototyping and testing. Each preset includes a contract owner, which is set in the `constructor`, to offer simple access control on sensitive methods such as `mint` and `burn`.
+
+### ERC721_Mintable_Burnable
+
+The `ERC721_Mintable_Burnable` preset offers a quick and easy setup for creating NFTs. The contract owner can create tokens with `mint`, whereas token owners can destroy their tokens with `burn`. 
+
+### ERC721_Mintable_Pausable  
+
+The `ERC721_Mintable_Pausable` preset creates a contract with pausable token transfers and minting capabilities. This preset proves useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch for freezing all token transfers in the event of a large bug. In this preset, only the contract owner can `mint`, `pause`, and `unpause`.
+
+### ERC721_Enumerable_Mintable_Burnable
+
+The `ERC721_Enumerable_Mintable_Burnable` preset adds enumerability of all the token ids in the contract as well as all token ids owned by each account. This allows contracts to publish its full list of NFTs and make them discoverable. 
+
+In regard to implementation, contracts should import the following view methods:
+-  `ERC721_Enumerable_totalSupply`
+-  `ERC721_Enumerable_tokenByIndex`
+-  `ERC721_Enumerable_tokenOfOwnerByIndex`
+
+In order for the tokens to be correctly indexed, the contract should also import the following methods (which supercede some of the `ERC721_base` methods):
+-  `ERC721_Enumerable_transferFrom`
+-  `ERC721_Enumerable_safeTransferFrom`
+-  `ERC721_Enumerable_mint`
+-  `ERC721_Enumerable_burn`
+
+#### IERC721_Enumerable
+
+```jsx
+@contract_interface
+namespace IERC721_Enumerable:
+    func totalSupply() -> (totalSupply: Uint256):
+    end
+
+    func tokenByIndex(index: Uint256) -> (tokenId: Uint256):
+    end
+
+    func tokenOfOwnerByIndex(owner: felt, index: Uint256) -> (tokenId: Uint256):
+    end
+end
+```
+
+### ERC721_Metadata
+
+The `ERC721_Metadata` extension allows your smart contract to be interrogated for its name and for details about the assets which your NFTs represent.
+
+We follow OpenZeppelin's Solidity approach of integrating the Metadata methods `name`, `symbol`, and `tokenURI` into all ERC721 implementations. If preferred, a contract can be created that does not import the Metadata methods from the `ERC721_base` library. Note that the `IERC721_Metadata` interface id should be removed from the constructor as well. 
+
+#### IERC721_Metadata
+
+```jsx
+@contract_interface
+namespace IERC721_Metadata:
+    func name() -> (name: felt):
+    end
+
+    func symbol() -> (symbol: felt):
+    end
+
+    func tokenURI(tokenId: Uint256) -> (tokenURI: felt):
+    end
+end
+```
+
+## Utilities
+
+### ERC721_Holder
+
+Implementation of the `IERC721Receiver` interface.
+
+Accepts all token transfers. Make sure the contract is able to use its token with `IERC721.safeTransferFrom`, `IERC721.approve` or `IERC721.setApprovalForAll`.
+
+Also utilizes the ERC165 method `supportsInterface` to determine if the contract is an account. See [ERC721Received](#erc721received)
+
+## API Specification
+
+### IERC721 API
+
+```jsx
+func balanceOf(owner: felt) -> (balance: Uint256):
+end
+
+func ownerOf(tokenId: Uint256) -> (owner: felt):
+end
+
+func safeTransferFrom(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256, 
+        data_len: felt,
+        data: felt*
+    ):
+end
+
+func transferFrom(from_: felt, to: felt, tokenId: Uint256):
+    end
+
+func approve(approved: felt, tokenId: Uint256):
+end
+
+func setApprovalForAll(operator: felt, approved: felt):
+end
+
+func getApproved(tokenId: Uint256) -> (approved: felt):
+end
+
+func isApprovedForAll(owner: felt, operator: felt) -> (isApproved: felt):
+end
+
+```
+
+#### `balanceOf`
+
+Returns the number of tokens in `owner`'s account.
+
+Parameters:
+
+```jsx
+owner: felt
+```
+
+Returns:
+
+```jsx
+balance: Uint256
+```
+
+#### `ownerOf`
+
+Returns the owner of the `tokenId` token.
+
+Parameters:
+
+```jsx
+tokenId: Uint256
+```
+
+Returns:
+
+```jsx
+owner: felt
+```
+
+#### `safeTransferFrom`
+
+Safely transfers `tokenId` token from `from_` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. For information regarding how contracts communicate their awareness of the ERC721 protocol, see [ERC721Received](#erc721received).
+
+Emits a [Transfer](#-Transfer-(event)-) event.
+
+Parameters:
+
+```jsx
+from_: felt
+to: felt
+tokenId: Uint256
+data_len: felt
+data: felt*
+```
+
+Returns:
+
+None.
+
+#### `transferFrom`
+
+Transfers `tokenId` token from `from_` to `to`.
+
+> Note that this function should be used instead of `safeTransferFrom` to transfer tokens. Exercise caution as tokens sent to a contract that does not support ERC721 can be lost forever.
+
+Emits a [Transfer](#-Transfer-(event)-) event.
+
+Parameters:
+
+```jsx
+from_: felt
+to: felt
+tokenId: Uint256
+```
+
+Returns:
+
+None.
+
+#### `approve`
+
+Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred.
+
+Emits an [Approval](#-Approval-(event)-) event.
+
+Parameters:
+
+```jsx
+to: felt
+tokenId: Uint256
+```
+
+Returns:
+
+None.
+
+#### `getApproved`
+
+Returns the account approved for `tokenId` token.
+
+Parameters:
+
+```jsx
+tokenId: Uint256
+```
+
+Returns:
+
+```jsx
+operator: felt
+```
+
+#### `setApprovalForAll`
+
+Approve or remove `operator` as an operator for the caller. Operators can call `transferFrom` or `safeTransferFrom` for any token owned by the caller.
+
+Emits an [ApprovalForAll](#-ApprovalForAll-(event)-) event.
+
+Parameters:
+
+```jsx
+operator: felt
+```
+
+Returns:
+
+None.
+
+#### `isApprovedForAll`
+
+Returns if the `operator` is allowed to manage all of the assets of `owner`.
+
+Parameters:
+
+```jsx
+owner: felt
+operator: felt
+```
+
+Returns:
+
+```jsx
+isApproved: felt
+```
+
+### Events
+
+#### `Approval (Event)`
+
+Emitted when `owner` enables `approved` to manage the `tokenId` token.
+
+Parameters:
+
+```jsx
+owner: felt
+approved: felt
+tokenId: Uint256
+```
+
+#### `ApprovalForAll (Event)`
+
+Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+
+Parameters:
+
+```jsx
+owner: felt
+operator: felt
+approved: felt
+```
+
+#### `Transfer (Event)`
+
+Emitted when `tokenId` token is transferred from `from_` to `to`.
+
+Parameters:
+
+```jsx
+from_: felt
+to: felt
+tokenId: Uint256
+```
+
+---
+
+### IERC721_Metadata API
+```jsx
+func name() -> (name: felt):
+end
+
+func symbol() -> (symbol: felt):
+end
+
+func tokenURI(tokenId: Uint256) -> (tokenURI: felt):
+end
+```
+
+#### `name`
+
+Returns the token collection name.
+
+Parameters:
+
+None.
+
+Returns:
+
+```jsx
+name: felt
+```
+
+#### `symbol`
+
+Returns the token collection symbol.
+
+Parameters: 
+
+None.
+
+Returns:
+
+```jsx
+symbol: felt
+```
+
+#### `tokenURI`
+
+Returns the Uniform Resource Identifier (URI) for `tokenID` token. If the URI is not set for the `tokenId`, the return value will be `0`.
+
+Parameters:
+
+```jsx
+tokenId: Uint256
+```
+
+Returns:
+
+```jsx
+tokenURI: felt
+```
+
+---
+
+### IERC721_Enumerable API
+```jsx
+
+func totalSupply() -> (totalSupply: Uint256):
+end
+
+func tokenByIndex(index: Uint256) -> (tokenId: Uint256):
+end
+
+func tokenOfOwnerByIndex(owner: felt, index: Uint256) -> (tokenId: Uint256):
+end
+```
+
+#### `totalSupply`
+
+Returns the total amount of tokens stored by the contract.
+
+Parameters: None
+
+Returns:
+
+```jsx
+totalSupply: Uint256
+```
+
+#### `tokenByIndex`
+
+Returns a token ID owned by `owner` at a given `index` of its token list. Use along with [balanceOf](#balanceOf) to enumerate all of `owner`'s tokens.
+
+Parameters:
+
+```jsx
+index: Uint256
+```
+
+Returns:
+
+```jsx
+tokenId: Uint256
+```
+
+#### `tokenOfOwnerByIndex`
+
+Returns a token ID at a given `index` of all the tokens stored by the contract. Use along with [totalSupply](#totalSupply) to enumerate all tokens.
+
+Parameters:
+
+```jsx
+owner: felt
+index: Uint256
+```
+
+Returns:
+
+```jsx
+tokenId: Uint256
+```
+
+---
+
+### IERC721_Receiver API
+```jsx
+func onERC721Received(
+        operator: felt, 
+        from_: felt, 
+        tokenId: Uint256, 
+        data_len: felt
+        data: felt*
+    ) -> (selector: felt):
+end
+```
+
+#### `onERC721Received`
+
+Whenever an IERC721 `tokenId` token is transferred to this non-account contract via `safeTransferFrom` by `operator` from `from_`, this function is called.
+
+
+Parameters:
+
+```jsx
+operator: felt
+from_: felt
+tokenId: Uint256
+data_len: felt
+data: felt*
+```
+
+Returns:
+
+```jsx
+selector: felt
+```
+
+## ERC165
+
+The ERC165 standard allows smart contracts to exercise [type introspection](https://en.wikipedia.org/wiki/Type_introspection) on other contracts, that is, examining which functions can be called on them. This is usually referred to as a contract’s interface.
+
+Cairo contracts, like Ethereum contracts, have no native concept of an interface, so applications must usually simply trust they are not making an incorrect call. For trusted setups this is a non-issue, but often unknown and untrusted third-party addresses need to be interacted with. There may even not be any direct calls to them! (e.g. ERC20 tokens may be sent to a contract that lacks a way to transfer them out of it, locking them forever). In these cases, a contract declaring its interface can be very helpful in preventing errors.
+
+It should be noted that the [constants library](../openzeppelin/utils/constants.cairo) includes constant variables referencing all of the interface ids used in these contracts. This allows for more legible code i.e. using `IERC165_ID` instead of `0x01ffc9a7`.
+
+
+### IERC165
+```jsx
+@contract_interface
+namespace IERC165:
+    func supportsInterface(interfaceId: felt) -> (success: felt):
+    end
+end
+```
+
+### ERC165 API Specification
+```jsx
+func supportsInterface(interfaceId: felt) -> (success: felt):
+end
+```
+
+#### `supportsInterface`
+
+Returns true if this contract implements the interface defined by `interfaceId`.
+
+Parameters:
+
+```jsx
+interfaceId: felt
+```
+
+Returns:
+
+```jsx
+success: felt
+```

--- a/openzeppelin/docs/Extensibility.md
+++ b/openzeppelin/docs/Extensibility.md
@@ -1,0 +1,92 @@
+# Extensibility
+
+> Expect this pattern to evolve (as it has already done) or even disappear if [proper extensibility features](https://community.starknet.io/t/contract-extensibility-pattern/210/11?u=martriay) are implemented into Cairo.
+
+* [The extensibility problem](#the-extensibility-problem)
+* [The pattern ™️](#the-pattern)
+  * [Libraries](#libraries)
+  * [Contracts](#contracts)
+* [Presets](#presets)
+* [Emulating hooks](#emulating-hooks)
+
+## The extensibility problem
+
+Smart contract development is a critical task. As with all software development, it is error prone; but unlike most scenarios, a bug can result in major losses for organizations as well as individuals. Therefore writing complex smart contracts is a delicate task.
+
+One of the best approaches to minimize introducing bugs is to reuse existing, battle-tested code, a.k.a. using libraries. But code reutilization in StarkNet’s smart contracts is not easy:
+
+- Cairo has no explicit smart contract extension mechanisms such as inheritance or composability
+- Using imports for modularity can result in clashes (more so given that arguments are not part of the selector), and lack of overrides or aliasing leaves no way to resolve them
+- Any `@external` function defined in an imported module will be automatically re-exposed by the importer (i.e. the smart contract)
+
+To overcome these problems, this project builds on the following guidelines™.
+
+## The pattern
+
+The idea is to have two types of Cairo modules: libraries and contracts. Libraries define reusable logic and storage variables which can then be extended and exposed by contracts. Contracts can be deployed, libraries cannot.
+
+To minimize risk, boilerplate, and avoid function naming clashes, we follow these rules:
+
+### Libraries
+
+- All function and storage variable names must be prefixed with the file name to prevent clashing with other libraries (e.g. `ERC20_approve` in the `ERC20` library)
+- Must not implement any `@external` or `@view` functions
+- Must not implement constructors
+- Must not call initializers on any function
+- Should implement initializer functions to mimic construction logic if needed (as any other library function, never as `@external`)
+
+### Contracts
+
+- Can import from libraries
+- Should implement `@external` functions if needed
+- Should implement a constructor that calls initializers
+- Must not call initializers in any function beside the constructor
+
+Note that since initializers will never be marked as `@external` and they won’t be called from anywhere but the contract constructor, there’s no risk of re-initialization after deployment. It’s up to the library developers not to make initializers interdependent to avoid weird dependency paths that may lead to double initialization of libraries.
+
+## Presets
+
+Presets are pre-written contracts that extend from our library of contracts. They can be deployed as-is or used as templates for customization.
+
+Some presets are:
+
+- [Account](../openzeppelin/account/Account.cairo)
+- [ERC165](../tests/mocks/ERC165.cairo)
+- [ERC20_Mintable](../openzeppelin/token/erc20/ERC20_Mintable.cairo)
+- [ERC20_Pausable](../openzeppelin/token/erc20/ERC20_Pausable.cairo)
+- [ERC20_Upgradeable](../openzeppelin/token/erc20/ERC20_Upgradeable.cairo)
+- [ERC20](../openzeppelin/token/erc20/ERC20.cairo)
+- [ERC721_Mintable_Burnable](../openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo)
+- [ERC721_Mintable_Pausable](../openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo)
+- [ERC721_Enumerable_Mintable_Burnable](../openzeppelin/token/erc721_enum/ERC721_Enumerable_Mintable_Burnable.cairo)
+
+## Emulating hooks
+
+Unlike the Solidity version of [OpenZeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts), this library does not implement [hooks](https://docs.openzeppelin.com/contracts/4.x/extending-contracts#using-hooks). The main reason being that Cairo does not support overriding functions.
+
+This is what a hook looks like in Solidity:
+
+```js
+abstract contract ERC20Pausable is ERC20, Pausable {
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
+        super._beforeTokenTransfer(from, to, amount);
+
+        require(!paused(), "ERC20Pausable: token transfer while paused");
+    }
+}
+```
+
+Instead, the extensibility pattern allows us to simply extend the library implementation of a function (namely `transfer`) by adding lines before or after calling it. This way, we can get away with:
+
+```python
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    Pausable_when_not_paused()
+    ERC20_transfer(recipient, amount)
+    return (TRUE)
+end
+```

--- a/openzeppelin/docs/Proxies.md
+++ b/openzeppelin/docs/Proxies.md
@@ -1,0 +1,273 @@
+# Proxies
+
+> Expect rapid iteration as this pattern matures and more patterns potentially emerge. 
+
+## Table of Contents
+* [Quickstart](#quickstart)
+* [Proxies](#proxies)
+  * [Proxy contract](#proxy-contract) 
+  * [Implementation contract](#implementation-contract)
+* [Upgrades library API](#upgrades-library-api)
+  * [Methods](#methods)
+  * [Events](#events)
+* [Using proxies](#using-proxies)
+  * [Contract upgrades](#contract-upgrades)
+  * [Handling method calls](#handling-method-calls)
+* [Presets](#presets)
+
+## Quickstart
+
+The general workflow is:
+1. deploy implementation contract
+2. deploy proxy contract with the implementation contract's address set in the proxy's constructor calldata
+3. initialize the implementation contract by sending a call to the proxy contract. This will redirect the call to the implementation contract and behave like the implementation contract's constructor
+
+In Python, this would look as follows:
+
+```python
+    # deploy implementation
+    IMPLEMENTATION = await starknet.deploy(
+        "path/to/implementation.cairo",
+        constructor_calldata=[]
+    )
+
+    # deploy proxy
+    PROXY = await starknet.deploy(
+        "path/to/proxy.cairo",
+        constructor_calldata=[
+            IMPLEMENTATION.contract_address,  # set implementation address
+        ]
+    )
+
+    # users should only interact with the proxy contract
+    await signer.send_transaction(
+        account, PROXY.contract_address, 'initialize', [
+            arg_1,
+            arg_2
+        ]
+    )
+```
+
+## Proxies
+
+A proxy contract is a contract that delegates function calls to another contract. This type of pattern decouples state and logic. Proxy contracts store the state and redirect function calls to an implementation contract that handles the logic. This allows for different patterns such as upgrades, where implementation contracts can change but the proxy contract (and thus the state) does not; as well as deploying multiple proxy instances pointing to the same implementation. This can be useful to deploy many contracts with identical logic but unique initialization data.
+
+In the case of contract upgrades, it is achieved by simply changing the proxy's reference to the implementation contract. This allows developers to add features, update logic, and fix bugs without touching the state or the contract address to interact with the application. 
+
+### Proxy contract
+
+The [Proxy contract](../openzeppelin/upgrades/Proxy.cairo) includes two core methods:  
+
+1. The `__default__` method is a fallback method that redirects a function call and associated calldata to the implementation contract. 
+
+2. The `__l1_default__` method is also a fallback method; however, it redirects the function call and associated calldata to a layer one contract. In order to invoke `__l1_default__`, the original function call must include the library function `send_message_to_l1`. See Cairo's [Interacting with L1 contracts](https://www.cairo-lang.org/docs/hello_starknet/l1l2.html) for more information.
+
+Since this proxy is designed to work both as an [UUPS-flavored upgrade proxy](https://eips.ethereum.org/EIPS/eip-1822) as well as a non-upgradeable proxy, it does not know how to handle its own state. Therefore it requires the implementation contract to be deployed beforehand, so its address can be passed to the Proxy on construction time.
+
+When interacting with the contract, function calls should be sent by the user to the proxy. The proxy's fallback function redirects the function call to the implementation contract to execute.
+
+
+### Implementation contract
+
+The implementation contract, also known as the logic contract, receives the redirected function calls from the proxy contract. The implementation contract should follow the [Extensibility pattern](../docs/Extensibility.md#the-pattern) and import directly from the [Proxy library](../openzeppelin/upgrades/library.cairo).
+ 
+
+The implementation contract should:
+- import `Proxy_initializer` and `Proxy_set_implementation`
+- initialize the proxy immediately after contract deployment.
+
+If the implementation is upgradeable, it should:
+- include a method to upgrade the implementation (i.e. `upgrade`)
+- use access control to protect the contract's upgradeability.
+
+The implementation contract should NOT:
+- deploy with a traditional constructor. Instead, use an initializer method that invokes `Proxy_initializer`.
+
+> Note that the imported `Proxy_initializer` includes a check the ensures the initializer can only be called once; however, `Proxy_set_implementation` does not include this check. It's up to the developers to protect their implementation contract's upgradeability with access controls such as [`Proxy_only_admin`](#Proxy_only_admin). 
+
+For a full implementation contract example, please see:
+- [Proxiable implementation](../tests/mocks/proxiable_implementation.cairo)
+
+## Upgrades library API
+
+### Methods
+```jsx
+func Proxy_initializer(proxy_admin: felt):
+end
+
+func Proxy_set_implementation(new_implementation: felt):
+end
+
+func Proxy_only_admin():
+end
+
+func Proxy_get_admin() -> (admin: felt):
+end
+
+func Proxy_get_implementation() -> (implementation: felt):
+end
+
+func Proxy_set_admin(new_admin: felt):
+end
+```
+
+#### `Proxy_initializer`
+
+Initializes the proxy contract with an initial implementation.
+
+Parameters:
+
+```jsx
+proxy_admin: felt
+```
+
+Returns:
+
+None.
+
+#### `Proxy_set_implementation`
+
+Sets the implementation contract. This method is included in the proxy contract's constructor and is furthermore used to upgrade contracts.
+
+Parameters:
+
+```jsx
+new_implementation: felt
+```
+
+Returns:
+
+None.
+
+#### `Proxy_only_admin`
+
+Throws if called by any account other than the admin.
+
+Parameters:
+
+None.
+
+Returns:
+
+None.
+
+#### `Proxy_get_admin`
+
+Returns the current admin.
+
+Parameters:
+
+None.
+
+Returns:
+
+```jsx
+admin: felt
+```
+
+#### `Proxy_get_implementation`
+
+Returns the current implementation address.
+
+Parameters:
+
+None.
+
+Returns:
+
+```jsx
+implementation: felt
+```
+
+#### `Proxy_set_admin`
+
+Sets the admin of the proxy contract.
+
+Parameters:
+
+```jsx
+new_admin: felt
+```
+
+Returns:
+
+None.
+
+### Events
+
+```jsx
+func Upgraded(implementation: felt):
+end
+```
+
+#### `Upgraded`
+
+Emitted when a proxy contract sets a new implementation address.
+
+Parameters:
+
+```jsx
+implementation: felt
+```
+
+## Using proxies 
+
+### Contract upgrades
+
+To upgrade a contract, the implementation contract should include an `upgrade` method that, when called, changes the reference to a new deployed contract like this:
+
+
+```python
+    # deploy first implementation
+    IMPLEMENTATION = await starknet.deploy(
+        "path/to/implementation.cairo",
+        constructor_calldata=[]
+    )
+
+    # deploy proxy
+    PROXY = await starknet.deploy(
+        "path/to/proxy.cairo",
+        constructor_calldata=[
+            IMPLEMENTATION.contract_address,  # set implementation address
+        ]
+    )
+
+    # deploy implementation v2
+    IMPLEMENTATION_V2 = await starknet.deploy(
+        "path/to/implementation_v2.cairo",
+        constructor_calldata=[]
+    )
+
+    # call upgrade with the new implementation contract address
+    await signer.send_transaction(
+        account, PROXY.contract_address, 'upgrade', [
+            IMPLEMENTATION_V2.contract_address
+        ]
+    )
+```
+
+For a full deployment and upgrade implementation, please see:
+- [Upgrades V1](../tests/mocks/upgrades_v1_mock.cairo)
+- [Upgrades V2](../tests/mocks/upgrades_v2_mock.cairo)
+
+### Handling method calls
+
+As with most StarkNet contracts, interacting with a proxy contract requires an [account abstraction](../docs/Account.md#quickstart). One notable difference with proxy contracts versus other contract implementations is that calling `@view` methods also requires an account abstraction. As of now, direct calls to default entrypoints are only supported by StarkNet's `syscalls` from other contracts i.e. account contracts. The differences in getter methods written in Python, for example, are as follows:
+
+```python
+# standard ERC20 call
+result = await erc20.totalSupply().call()
+
+# upgradeable ERC20 call
+result = await signer.send_transaction(
+        account, PROXY.contract_address, 'totalSupply', []
+    )
+```
+
+## Presets
+
+Presets are pre-written contracts that extend from our library of contracts. They can be deployed as-is or used as templates for customization. 
+
+Some presets include:
+- [ERC20_Upgradeable](../openzeppelin/token/erc20/ERC20_Upgradeable.cairo)
+- more to come! have an idea? [open an issue](https://github.com/OpenZeppelin/cairo-contracts/issues/new/choose)!

--- a/openzeppelin/docs/Utilities.md
+++ b/openzeppelin/docs/Utilities.md
@@ -1,0 +1,237 @@
+# Utilities
+
+The following documentation provides context, reasoning, and examples for methods and constants found in `tests/utils.py`.  
+
+> Expect this module to evolve (as it has already done).
+
+## Table of Contents
+
+* [Constants](#constants)
+* [Interface ids](#interface-ids)
+* [Strings](#strings)
+  * [`str_to_felt`](#str_to_felt)
+  * [`felt_to_str`](#felt_to_str)
+* [Uint256](#uint256)
+  * [`uint`](#uint)
+  * [`to_uint`](#to_uint)
+  * [`from_uint`](#from_uint)
+  * [`add_uint`](#add_uint)
+  * [`sub_uint`](#sub_uint)
+* [Assertions](#assertions)
+  * [`assert_revert`](#assert_revert)
+  * [`assert_events_emitted`](#assert_events_emitted)
+* [Memoization](#memoization)
+  * [`get_contract_def`](#get_contract_def)
+  * [`cached_contract`](#cached_contract)
+* [Signer](#signer)
+
+## Constants
+
+The Cairo programming language includes unique features and limitations relative to other programming languages. To ease the readability of Cairo contracts, this project includes reusable constant variables like `TRUE`, `FALSE`, or `ZERO_ADDRESS`.
+
+## Interface ids
+
+The [constants library](../openzeppelin/utils/constants.cairo) lists all of the interface ids used by our libaries as constant variables to increase code legibility. For example, `IERC165_ID` is much easier to read than `0x01ffc9a7`. For more information on how interface ids are calculated, see the [ERC165 documentation](../docs/ERC721.md#erc165).
+
+## Strings
+
+Cairo currently only provides support for short string literals (less than 32 characters). Note that short strings aren't really strings, rather, they're representations of Cairo field elements. The following methods provide a simple conversion to/from field elements. 
+
+### `str_to_felt`
+
+Takes an ASCII string and converts it to a field element via big endian representation.
+
+
+### `felt_to_str`
+
+Takes an integer and converts it to an ASCII string by trimming the null bytes and decoding the remaining bits.
+
+## Uint256
+
+Cairo's native data type is a field element (felt). Felts equate to 252 bits which poses a problem regarding 256-bit integer integration. To resolve the bit discrepancy, Cairo represents 256-bit integers as a struct of two 128-bit integers. Further, the low bits precede the high bits e.g.
+
+```
+1 = (1, 0)
+1 << 128 = (0, 1)
+(1 << 128) - 1 = (340282366920938463463374607431768211455, 0)
+```
+
+### `uint`
+
+Converts a simple integer into a uint256-ish tuple.
+
+> Note `to_uint` should be used in favor of `uint`, as `uint` only returns the low bits of the tuple.
+
+
+### `to_uint`
+
+Converts an integer into a uint256-ish tuple.
+
+```python
+x = to_uint(340282366920938463463374607431768211456)
+print(x)
+# prints (0, 1)
+```
+
+### `from_uint`
+
+Converts a uin256-ish tuple into an integer.
+
+```python
+x = (0, 1)
+y = from_uint(x)
+print(y)
+# prints 340282366920938463463374607431768211456
+```
+
+### `add_uint`
+
+Performs addition between two uint256-ish tuples and returns the sum as a uint256-ish tuple.
+
+```python
+x = (0, 1)
+y = (1, 0)
+z = add_uint(x, y)
+print(z)
+# prints (1, 1)
+```
+
+### `sub_uint`
+
+Performs subtraction between two uint256-ish tuples and returns the difference as a uint256-ish tuple.
+
+```python
+x = (0, 1)
+y = (1, 0)
+z = sub_uint(x, y)
+print(z)
+# prints (340282366920938463463374607431768211455, 0)
+```
+
+### `mul_uint`
+
+Performs multiplication between two uint256-ish tuples and returns the product as a uint256-ish tuple.
+
+```python
+x = (0, 10)
+y = (2, 0)
+z = mul_uint(x, y)
+print(z)
+# prints (0, 20)
+```
+
+### `div_rem_uint`
+
+Performs division between two uint256-ish tuples and returns both the quotient and remainder as uint256-ish tuples respectively.
+
+```python
+x = (1, 100)
+y = (0, 25)
+z = div_rem_uint(x, y)
+print(z)
+# prints ((4, 0), (1, 0)) 
+```
+
+## Assertions
+
+In order to abstract away some of the verbosity regarding test assertions on StarkNet transactions, this project includes the following helper methods:
+
+### `assert_revert`
+
+An asynchronous wrapper method that executes a try-except pattern for transactions that should fail. Note that this wrapper does not check for a StarkNet error code. This allows for more flexibility in checking that a transaction simply failed. If you wanted to check for an exact error code, you could use StarkNet's [error_codes module](https://github.com/starkware-libs/cairo-lang/blob/ed6cf8d6cec50a6ad95fa36d1eb4a7f48538019e/src/starkware/starknet/definitions/error_codes.py) and implement additional logic to the `assert_revert` method.
+
+ To successfully use this wrapper, the transaction method should be wrapped with `assert_revert`; however, `await` should precede the wrapper itself like this:
+
+```python
+await assert_revert(signer.send_transaction(
+    account, contract.contract_address, 'foo', [
+        recipient,
+        *token
+    ])
+)
+```
+
+This wrapper also includes the option to check that an error message was included in the reversion. To check that the reversion sends the correct error message, add the `reverted_with` keyword argument outside of the actual transaction (but still inside the wrapper) like this:
+
+```python
+await assert_revert(signer.send_transaction(
+    account, contract.contract_address, 'foo', [
+        recipient,
+        *token
+    ]),
+    reverted_with="insert error message here"
+)
+```
+
+### `assert_event_emitted`
+
+A helper method that checks a transaction receipt for the contract emitting the event (`from_address`), the emitted event itself (`name`), and the arguments emitted (`data`). To use `assert_event_emitted`:
+
+```python
+# capture the tx receipt
+tx_exec_info = await signer.send_transaction(
+    account, contract.contract_address, 'foo', [
+        recipient,
+        *token
+    ])
+
+# insert arguments to assert
+assert_event_emitted(
+    tx_exec_info,
+    from_address=contract.contract_address,
+    name='Foo_emitted',
+    data=[
+        account.contract_address,
+        recipient,
+        *token
+    ]
+)
+```
+
+## Memoization
+
+Memoizing functions allow for quicker and computationally cheaper calculations which is immensely beneficial while testing smart contracts. 
+
+### `get_contract_def`
+
+A helper method that returns the contract definition from the given path. To capture the contract definition, simply add the contracat path as an argument like this:
+
+```python
+contract_definition = get_contract_def('path/to/contract.cairo')
+```
+
+### `cached_contract`
+
+A helper method that returns the cached state of a given contract. It's recommended to first deploy all the relevant contracts before caching the state. The requisite contracts in the testing module should each be instantiated with `cached_contract` in a fixture after the state has been copied. The memoization pattern with `cached_contract` should look something like this:
+
+```python
+# get contract definitions
+@pytest.fixture(scope='module')
+def contract_defs():
+  foo_def = get_contract_def('path/to/foo.cairo')
+  return foo_def
+
+# deploy contracts
+@pytest.fixture(scope='module')
+async def foo_init(contract_defs):
+    foo_def = contract_defs
+    starknet = await Starknet.empty()
+    foo = await starknet.deploy(
+        contract_def=foo_def,
+        constructor_calldata=[]
+    )
+    return starknet.state, foo  # return state and all deployed contracts
+
+# memoization
+@pytest.fixture(scope='module')
+def foo_factory(contract_defs, foo_init):
+    foo_def = contract_defs  # contract definitions
+    state, foo = foo_init  # state and deployed contracts
+    _state = state.copy()  # copy the state
+    cached_foo = cached_contract(_state, foo_def, foo)  # cache contracts
+    return cached_foo  # return cached contracts
+```
+
+## Signer
+
+`Signer` is used to perform transactions on a given Account, crafting the tx and managing nonces. See the [Account documentation](../docs/Account.md#signer-utility) for in-depth information.

--- a/openzeppelin/pyproject.toml
+++ b/openzeppelin/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+# AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
+requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# See configuration details in https://github.com/pypa/setuptools_scm
+version_scheme = "no-guess-dev"

--- a/openzeppelin/setup.cfg
+++ b/openzeppelin/setup.cfg
@@ -1,0 +1,37 @@
+[metadata]
+name = openzeppelin-cairo-contracts
+version = attr: openzeppelin-cairo-contracts.__version__
+description = Library for secure smart contract development written in Cairo
+author = OpenZeppelin Community
+author_email = maintainers@openzeppelin.org
+license = MIT
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+url = https://github.com/OpenZeppelin/cairo-contracts
+platforms = any
+classifiers =
+    Operating System :: OS Independent
+
+[options]
+zip_safe = False
+packages = find_namespace:
+include_package_data = True
+package_dir =
+    =src
+
+install_requires =
+    importlib-metadata>=4.0
+
+[options.packages.find]
+where = src
+exclude =
+    tests
+
+[options.package_data]
+openzeppelin = "*.cairo"
+
+[options.extras_require]
+testing =
+    setuptools
+    tox
+    pytest

--- a/openzeppelin/setup.py
+++ b/openzeppelin/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    try:
+        setup(use_scm_version={"version_scheme": "no-guess-dev"})
+    except:  # noqa
+        print(
+            "\n\nAn error occurred while building the project, "
+            "please ensure you have the most updated version of setuptools, "
+            "setuptools_scm and wheel with:\n"
+            "   pip install -U setuptools setuptools_scm wheel\n\n"
+        )
+        raise

--- a/openzeppelin/src/openzeppelin/__init__.py
+++ b/openzeppelin/src/openzeppelin/__init__.py
@@ -1,0 +1,11 @@
+"""StarkNet/Cairo development toolbelt."""
+
+try:
+    from importlib import metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+try:
+    __version__ = importlib_metadata.version("openzeppelin-cairo-contracts")
+except importlib_metadata.PackageNotFoundError:
+    __version__ = None

--- a/openzeppelin/src/openzeppelin/access/ownable.cairo
+++ b/openzeppelin/src/openzeppelin/access/ownable.cairo
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (access/ownable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+
+@storage_var
+func Ownable_owner() -> (owner: felt):
+end
+
+func Ownable_initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt):
+    Ownable_owner.write(owner)
+    return ()
+end
+
+func Ownable_only_owner{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }():
+    let (owner) = Ownable_owner.read()
+    let (caller) = get_caller_address()
+    with_attr error_message("Ownable: caller is not the owner"):
+        assert owner = caller
+    end
+    return ()
+end
+
+func Ownable_get_owner{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (owner: felt):
+    let (owner) = Ownable_owner.read()
+    return (owner=owner)
+end
+
+func Ownable_transfer_ownership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_owner: felt) -> (new_owner: felt):
+    Ownable_only_owner()
+    Ownable_owner.write(new_owner)
+    return (new_owner=new_owner)
+end

--- a/openzeppelin/src/openzeppelin/account/Account.cairo
+++ b/openzeppelin/src/openzeppelin/account/Account.cairo
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (account/Account.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from openzeppelin.account.library import (
+    AccountCallArray,
+    Account_execute,
+    Account_get_nonce,
+    Account_initializer,
+    Account_get_public_key,
+    Account_set_public_key,
+    Account_is_valid_signature
+)
+
+from openzeppelin.introspection.ERC165 import ERC165_supports_interface 
+
+#
+# Getters
+#
+
+@view
+func get_public_key{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = Account_get_public_key()
+    return (res=res)
+end
+
+@view
+func get_nonce{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = Account_get_nonce()
+    return (res=res)
+end
+
+@view
+func supportsInterface{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    } (interfaceId: felt) -> (success: felt):
+    let (success) = ERC165_supports_interface(interfaceId)
+    return (success)
+end
+
+#
+# Setters
+#
+
+@external
+func set_public_key{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_public_key: felt):
+    Account_set_public_key(new_public_key)
+    return ()
+end
+
+#
+# Constructor
+#
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(public_key: felt):
+    Account_initializer(public_key)
+    return ()
+end
+
+#
+# Business logic
+#
+
+@view
+func is_valid_signature{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr, 
+        ecdsa_ptr: SignatureBuiltin*
+    }(
+        hash: felt,
+        signature_len: felt,
+        signature: felt*
+    ) -> ():
+    Account_is_valid_signature(hash, signature_len, signature)
+    return ()
+end
+
+@external
+func __execute__{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr, 
+        ecdsa_ptr: SignatureBuiltin*
+    }(
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata_len: felt,
+        calldata: felt*,
+        nonce: felt
+    ) -> (response_len: felt, response: felt*):
+    let (response_len, response) = Account_execute(
+        call_array_len,
+        call_array,
+        calldata_len,
+        calldata,
+        nonce
+    )
+    return (response_len=response_len, response=response)
+end

--- a/openzeppelin/src/openzeppelin/account/AddressRegistry.cairo
+++ b/openzeppelin/src/openzeppelin/account/AddressRegistry.cairo
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (account/AddressRegistry.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+
+@storage_var
+func L1_address(L2_address: felt) -> (res: felt):
+end
+
+@external
+func get_L1_address{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(L2_address: felt) -> (res: felt):
+    let (res) = L1_address.read(L2_address)
+    return (res=res)
+end
+
+@external
+func set_L1_address{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_L1_address: felt):
+    let (caller) = get_caller_address()
+    L1_address.write(caller, new_L1_address)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/account/IAccount.cairo
+++ b/openzeppelin/src/openzeppelin/account/IAccount.cairo
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (account/IAccount.cairo)
+
+%lang starknet
+
+from openzeppelin.account.Account import AccountCallArray
+
+@contract_interface
+namespace IAccount:
+
+    #
+    # Getters
+    #
+
+    func get_nonce() -> (res : felt):
+    end
+
+    #
+    # Business logic
+    #
+
+    func is_valid_signature(
+            hash: felt,
+            signature_len: felt,
+            signature: felt*
+        ):
+    end
+
+    func __execute__(
+            call_array_len: felt,
+            call_array: AccountCallArray*,
+            calldata_len: felt,
+            calldata: felt*,
+            nonce: felt
+        ) -> (response_len: felt, response: felt*):
+    end
+end

--- a/openzeppelin/src/openzeppelin/account/library.cairo
+++ b/openzeppelin/src/openzeppelin/account/library.cairo
@@ -1,0 +1,237 @@
+%lang starknet
+
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.starknet.common.syscalls import get_contract_address
+from starkware.cairo.common.signature import verify_ecdsa_signature
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.memcpy import memcpy
+from starkware.starknet.common.syscalls import call_contract, get_caller_address, get_tx_info
+from starkware.cairo.common.hash_state import (
+    hash_init, hash_finalize, hash_update, hash_update_single
+)
+
+from openzeppelin.introspection.ERC165 import (
+    ERC165_supports_interface, 
+    ERC165_register_interface
+)
+
+from openzeppelin.utils.constants import IACCOUNT_ID
+
+#
+# Structs
+#
+
+struct Call:
+    member to: felt
+    member selector: felt
+    member calldata_len: felt
+    member calldata: felt*
+end
+
+# Tmp struct introduced while we wait for Cairo
+# to support passing `[AccountCall]` to __execute__
+struct AccountCallArray:
+    member to: felt
+    member selector: felt
+    member data_offset: felt
+    member data_len: felt
+end
+
+#
+# Storage
+#
+
+@storage_var
+func Account_current_nonce() -> (res: felt):
+end
+
+@storage_var
+func Account_public_key() -> (res: felt):
+end
+
+#
+# Guards
+#
+
+func Account_assert_only_self{syscall_ptr : felt*}():
+    let (self) = get_contract_address()
+    let (caller) = get_caller_address()
+    with_attr error_message("Account: caller is not this account"):
+        assert self = caller
+    end
+    return ()
+end
+
+#
+# Getters
+#
+
+func Account_get_public_key{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = Account_public_key.read()
+    return (res=res)
+end
+
+func Account_get_nonce{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = Account_current_nonce.read()
+    return (res=res)
+end
+
+#
+# Setters
+#
+
+func Account_set_public_key{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_public_key: felt):
+    Account_assert_only_self()
+    Account_public_key.write(new_public_key)
+    return ()
+end
+
+#
+# Initializer
+#
+
+func Account_initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(_public_key: felt):
+    Account_public_key.write(_public_key)
+    ERC165_register_interface(IACCOUNT_ID)
+    return()
+end
+
+#
+# Business logic
+#
+
+@view
+func Account_is_valid_signature{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr, 
+        ecdsa_ptr: SignatureBuiltin*
+    }(
+        hash: felt,
+        signature_len: felt,
+        signature: felt*
+    ) -> ():
+    let (_public_key) = Account_public_key.read()
+
+    # This interface expects a signature pointer and length to make
+    # no assumption about signature validation schemes.
+    # But this implementation does, and it expects a (sig_r, sig_s) pair.
+    let sig_r = signature[0]
+    let sig_s = signature[1]
+
+    verify_ecdsa_signature(
+        message=hash,
+        public_key=_public_key,
+        signature_r=sig_r,
+        signature_s=sig_s)
+
+    return ()
+end
+
+
+func Account_execute{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr, 
+        ecdsa_ptr: SignatureBuiltin*
+    }(
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata_len: felt,
+        calldata: felt*,
+        nonce: felt
+    ) -> (response_len: felt, response: felt*):
+    alloc_locals
+
+    let (__fp__, _) = get_fp_and_pc()
+    let (tx_info) = get_tx_info()
+    let (_current_nonce) = Account_current_nonce.read()
+
+    # validate nonce
+    assert _current_nonce = nonce
+
+    # TMP: Convert `AccountCallArray` to 'Call'.
+    let (calls : Call*) = alloc()
+    from_call_array_to_call(call_array_len, call_array, calldata, calls)
+    let calls_len = call_array_len
+
+    # validate transaction
+    Account_is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature)
+
+    # bump nonce
+    Account_current_nonce.write(_current_nonce + 1)
+
+    # execute call
+    let (response : felt*) = alloc()
+    let (response_len) = execute_list(calls_len, calls, response)
+
+    return (response_len=response_len, response=response)
+end
+
+func execute_list{syscall_ptr: felt*}(
+        calls_len: felt,
+        calls: Call*,
+        response: felt*
+    ) -> (response_len: felt):
+    alloc_locals
+
+    # if no more calls
+    if calls_len == 0:
+       return (0)
+    end
+    
+    # do the current call
+    let this_call: Call = [calls]
+    let res = call_contract(
+        contract_address=this_call.to,
+        function_selector=this_call.selector,
+        calldata_size=this_call.calldata_len,
+        calldata=this_call.calldata
+    )
+    # copy the result in response
+    memcpy(response, res.retdata, res.retdata_size)
+    # do the next calls recursively
+    let (response_len) = execute_list(calls_len - 1, calls + Call.SIZE, response + res.retdata_size)
+    return (response_len + res.retdata_size)
+end
+
+func from_call_array_to_call{syscall_ptr: felt*}(
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata: felt*,
+        calls: Call*
+    ):
+    # if no more calls
+    if call_array_len == 0:
+       return ()
+    end
+    
+    # parse the current call
+    assert [calls] = Call(
+            to=[call_array].to,
+            selector=[call_array].selector,
+            calldata_len=[call_array].data_len,
+            calldata=calldata + [call_array].data_offset
+        )
+    
+    # parse the remaining calls recursively
+    from_call_array_to_call(call_array_len - 1, call_array + AccountCallArray.SIZE, calldata, calls + Call.SIZE)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/introspection/ERC165.cairo
+++ b/openzeppelin/src/openzeppelin/introspection/ERC165.cairo
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (introspection/ERC165.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.math import assert_not_equal
+
+from openzeppelin.utils.constants import TRUE, INVALID_ID, IERC165_ID
+
+@storage_var
+func ERC165_supported_interfaces(interface_id: felt) -> (is_supported: felt):
+end 
+
+func ERC165_supports_interface{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (interface_id: felt) -> (success: felt):
+    if interface_id == IERC165_ID:
+        return (TRUE)
+    end
+
+    # Checks interface registry
+    let (is_supported) = ERC165_supported_interfaces.read(interface_id)
+    return (is_supported)
+end
+
+func ERC165_register_interface{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (interface_id: felt):
+    with_attr error_message("ERC165: invalid interface id"):
+        assert_not_equal(interface_id, INVALID_ID)
+    end
+    ERC165_supported_interfaces.write(interface_id, TRUE)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/introspection/IERC165.cairo
+++ b/openzeppelin/src/openzeppelin/introspection/IERC165.cairo
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (introspection/IERC165.cairo)
+
+%lang starknet
+
+@contract_interface
+namespace IERC165:
+    func supportsInterface(interfaceId: felt) -> (success: felt):
+    end
+end

--- a/openzeppelin/src/openzeppelin/security/initializable.cairo
+++ b/openzeppelin/src/openzeppelin/security/initializable.cairo
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (security/initializable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from openzeppelin.utils.constants import TRUE, FALSE
+
+@storage_var
+func _initialized() -> (res: felt):
+end
+
+@external
+func initialized{ 
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (res: felt):
+    let (res) = _initialized.read()
+    return (res=res)
+end
+
+@external
+func initialize{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }():
+    let (initialized) = _initialized.read()
+    with_attr error_message("Initializable: contract already initialized"):
+        assert initialized = FALSE
+    end
+    _initialized.write(TRUE)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/security/pausable.cairo
+++ b/openzeppelin/src/openzeppelin/security/pausable.cairo
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (security/pausable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+
+from openzeppelin.utils.constants import TRUE, FALSE
+
+@storage_var
+func Pausable_paused() -> (paused: felt):
+end
+
+func Pausable_when_not_paused{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }():
+    let (is_paused) = Pausable_paused.read()
+    with_attr error_message("Pausable: contract is paused"):
+        assert is_paused = FALSE
+    end
+    return ()
+end
+
+func Pausable_when_paused{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }():
+    let (is_paused) = Pausable_paused.read()
+    with_attr error_message("Pausable: contract is not paused"):
+        assert is_paused = TRUE
+    end
+    return ()
+end
+
+func Pausable_pause{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }():
+    Pausable_when_not_paused()
+    Pausable_paused.write(TRUE)
+    return ()
+end
+
+func Pausable_unpause{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }():
+    Pausable_when_paused()
+    Pausable_paused.write(FALSE)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/security/safemath.cairo
+++ b/openzeppelin/src/openzeppelin/security/safemath.cairo
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (security/safemath.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_check, uint256_add, uint256_sub, uint256_mul, 
+    uint256_unsigned_div_rem, uint256_le, uint256_lt, uint256_eq
+)
+from openzeppelin.utils.constants import TRUE, FALSE
+
+# Adds two integers. 
+# Reverts if the sum overflows.
+func uint256_checked_add{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256):
+    uint256_check(a)
+    uint256_check(b)
+    let (c: Uint256, is_overflow) = uint256_add(a, b)
+    with_attr error_message("Safemath: addition overflow"):
+        assert is_overflow = FALSE
+    end
+    return (c)
+end
+
+# Subtracts two integers.
+# Reverts if minuend (`b`) is greater than subtrahend (`a`).
+func uint256_checked_sub_le{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256):
+    alloc_locals
+    uint256_check(a)
+    uint256_check(b)
+    let (is_le) = uint256_le(b, a)
+    with_attr error_message("Safemath: subtraction overflow"):
+        assert is_le = TRUE
+    end
+    let (c: Uint256) = uint256_sub(a, b)
+    return (c)
+end
+
+# Subtracts two integers.
+# Reverts if minuend (`b`) is greater than or equal to subtrahend (`a`).
+func uint256_checked_sub_lt{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256):
+    alloc_locals
+    uint256_check(a)
+    uint256_check(b)
+
+    let (is_lt) = uint256_lt(b, a)
+    with_attr error_message("Safemath: subtraction overflow or the difference equals zero"):
+        assert is_lt = TRUE
+    end
+    let (c: Uint256) = uint256_sub(a, b)
+    return (c)
+end
+
+# Multiplies two integers.
+# Reverts if product is greater than 2^256.
+func uint256_checked_mul{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256):
+    alloc_locals
+    uint256_check(a)
+    uint256_check(b)
+    let (a_zero) = uint256_eq(a, Uint256(0, 0))
+    if a_zero == TRUE:
+        return (a)
+    end
+
+    let (b_zero) = uint256_eq(b, Uint256(0, 0))
+    if b_zero == TRUE:
+        return (b)
+    end
+
+    let (c: Uint256, overflow: Uint256) = uint256_mul(a, b)
+    with_attr error_message("Safemath: multiplication overflow"):
+        assert overflow = Uint256(0, 0)
+    end
+    return (c)
+end
+
+# Integer division of two numbers. Returns uint256 quotient and remainder.
+# Reverts if divisor is zero as per OpenZeppelin's Solidity implementation.
+# Cairo's `uint256_unsigned_div_rem` already checks:
+#    remainder < divisor
+#    quotient * divisor + remainder == dividend
+func uint256_checked_div_rem{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256, rem: Uint256):
+    alloc_locals
+    uint256_check(a)
+    uint256_check(b)
+    
+    let (is_zero) = uint256_eq(b, Uint256(0, 0))
+    with_attr error_message("Safemath: divisor cannot be zero"):
+        assert is_zero = FALSE
+    end
+
+    let (c: Uint256, rem: Uint256) = uint256_unsigned_div_rem(a, b)
+    return (c, rem)
+end

--- a/openzeppelin/src/openzeppelin/token/erc20/ERC20.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc20/ERC20.cairo
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc20.library import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom,
+    ERC20_mint
+)
+
+from openzeppelin.utils.constants import TRUE
+
+@constructor
+func constructor{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        decimals: felt,
+        initial_supply: Uint256,
+        recipient: felt
+    ):
+    ERC20_initializer(name, symbol, decimals)
+    ERC20_mint(recipient, initial_supply)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC20_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC20_symbol()
+    return (symbol)
+end
+
+@view
+func totalSupply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC20_totalSupply()
+    return (totalSupply)
+end
+
+@view
+func decimals{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (decimals: felt):
+    let (decimals) = ERC20_decimals()
+    return (decimals)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC20_balanceOf(account)
+    return (balance)
+end
+
+@view
+func allowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+    return (remaining)
+end
+
+#
+# Externals
+#
+
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    ERC20_transfer(recipient, amount)
+    return (TRUE)
+end
+
+@external
+func transferFrom{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (success: felt):
+    ERC20_transferFrom(sender, recipient, amount)
+    return (TRUE)
+end
+
+@external
+func approve{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, amount: Uint256) -> (success: felt):
+    ERC20_approve(spender, amount)
+    return (TRUE)
+end
+
+@external
+func increaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, added_value: Uint256) -> (success: felt):
+    ERC20_increaseAllowance(spender, added_value)
+    return (TRUE)
+end
+
+@external
+func decreaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+    ERC20_decreaseAllowance(spender, subtracted_value)
+    return (TRUE)
+end

--- a/openzeppelin/src/openzeppelin/token/erc20/ERC20_Mintable.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc20/ERC20_Mintable.cairo
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20_Mintable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc20.library import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom,
+    ERC20_mint
+)
+
+from openzeppelin.access.ownable import (
+    Ownable_initializer,
+    Ownable_only_owner
+)
+
+from openzeppelin.utils.constants import TRUE
+
+@constructor
+func constructor{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        decimals: felt,
+        initial_supply: Uint256,
+        recipient: felt,
+        owner: felt
+    ):
+    ERC20_initializer(name, symbol, decimals)
+    ERC20_mint(recipient, initial_supply)
+    Ownable_initializer(owner)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC20_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC20_symbol()
+    return (symbol)
+end
+
+@view
+func totalSupply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC20_totalSupply()
+    return (totalSupply)
+end
+
+@view
+func decimals{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (decimals: felt):
+    let (decimals) = ERC20_decimals()
+    return (decimals)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC20_balanceOf(account)
+    return (balance)
+end
+
+@view
+func allowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+    return (remaining)
+end
+
+#
+# Externals
+#
+
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    ERC20_transfer(recipient, amount)
+    return (TRUE)
+end
+
+@external
+func transferFrom{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (success: felt):
+    ERC20_transferFrom(sender, recipient, amount)
+    return (TRUE)
+end
+
+@external
+func approve{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, amount: Uint256) -> (success: felt):
+    ERC20_approve(spender, amount)
+    return (TRUE)
+end
+
+@external
+func increaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, added_value: Uint256) -> (success: felt):
+    ERC20_increaseAllowance(spender, added_value)
+    return (TRUE)
+end
+
+@external
+func decreaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+    ERC20_decreaseAllowance(spender, subtracted_value)
+    return (TRUE)
+end
+
+@external
+func mint{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(to: felt, amount: Uint256):
+    Ownable_only_owner()
+    ERC20_mint(to, amount)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc20/ERC20_Pausable.cairo
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20_Pausable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc20.library import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom,
+    ERC20_mint
+)
+
+from openzeppelin.access.ownable import (
+    Ownable_initializer,
+    Ownable_only_owner
+)
+
+from openzeppelin.security.pausable import (
+    Pausable_paused,
+    Pausable_pause,
+    Pausable_unpause,
+    Pausable_when_not_paused
+)
+
+from openzeppelin.utils.constants import TRUE
+
+@constructor
+func constructor{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        decimals: felt,
+        initial_supply: Uint256,
+        recipient: felt,
+        owner: felt
+    ):
+    ERC20_initializer(name, symbol, decimals)
+    ERC20_mint(recipient, initial_supply)
+    Ownable_initializer(owner)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC20_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC20_symbol()
+    return (symbol)
+end
+
+@view
+func totalSupply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC20_totalSupply()
+    return (totalSupply)
+end
+
+@view
+func decimals{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (decimals: felt):
+    let (decimals) = ERC20_decimals()
+    return (decimals)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC20_balanceOf(account)
+    return (balance)
+end
+
+@view
+func allowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+    return (remaining)
+end
+
+@view
+func paused{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (paused: felt):
+    let (paused) = Pausable_paused.read()
+    return (paused)
+end
+
+#
+# Externals
+#
+
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    Pausable_when_not_paused()
+    ERC20_transfer(recipient, amount)
+    return (TRUE)
+end
+
+@external
+func transferFrom{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (success: felt):
+    Pausable_when_not_paused()
+    ERC20_transferFrom(sender, recipient, amount)
+    return (TRUE)
+end
+
+@external
+func approve{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, amount: Uint256) -> (success: felt):
+    Pausable_when_not_paused()
+    ERC20_approve(spender, amount)
+    return (TRUE)
+end
+
+@external
+func increaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, added_value: Uint256) -> (success: felt):
+    Pausable_when_not_paused()
+    ERC20_increaseAllowance(spender, added_value)
+    return (TRUE)
+end
+
+@external
+func decreaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+    Pausable_when_not_paused()
+    ERC20_decreaseAllowance(spender, subtracted_value)
+    return (TRUE)
+end
+
+@external
+func pause{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Ownable_only_owner()
+    Pausable_pause()
+    return ()
+end
+
+@external
+func unpause{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Ownable_only_owner()
+    Pausable_unpause()
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc20/ERC20_Upgradeable.cairo
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20_Upgradeable.cairo)
+
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc20.library import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom,
+    ERC20_mint
+)
+
+from openzeppelin.upgrades.library import (
+    Proxy_initializer,
+    Proxy_only_admin,
+    Proxy_set_implementation
+)
+
+from openzeppelin.utils.constants import TRUE
+
+#
+# Initializer
+#
+
+@external
+func initializer{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        decimals: felt,
+        initial_supply: Uint256,
+        recipient: felt,
+        proxy_admin: felt
+    ):
+    ERC20_initializer(name, symbol, decimals)
+    ERC20_mint(recipient, initial_supply)
+    Proxy_initializer(proxy_admin)
+    return ()
+end
+
+@external
+func upgrade{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_implementation: felt):
+    Proxy_only_admin()
+    Proxy_set_implementation(new_implementation)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC20_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC20_symbol()
+    return (symbol)
+end
+
+@view
+func totalSupply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC20_totalSupply()
+    return (totalSupply)
+end
+
+@view
+func decimals{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (decimals: felt):
+    let (decimals) = ERC20_decimals()
+    return (decimals)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC20_balanceOf(account)
+    return (balance)
+end
+
+@view
+func allowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+    return (remaining)
+end
+
+#
+# Externals
+#
+
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    ERC20_transfer(recipient, amount)
+    return (TRUE)
+end
+
+@external
+func transferFrom{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (success: felt):
+    ERC20_transferFrom(sender, recipient, amount)
+    return (TRUE)
+end
+
+@external
+func approve{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, amount: Uint256) -> (success: felt):
+    ERC20_approve(spender, amount)
+    return (TRUE)
+end
+
+@external
+func increaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, added_value: Uint256) -> (success: felt):
+    ERC20_increaseAllowance(spender, added_value)
+    return (TRUE)
+end
+
+@external
+func decreaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+    ERC20_decreaseAllowance(spender, subtracted_value)
+    return (TRUE)
+end

--- a/openzeppelin/src/openzeppelin/token/erc20/interfaces/IERC20.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc20/interfaces/IERC20.cairo
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/interfaces/IERC20.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC20:
+    func name() -> (name: felt):
+    end
+
+    func symbol() -> (symbol: felt):
+    end
+
+    func decimals() -> (decimals: felt):
+    end
+
+    func totalSupply() -> (totalSupply: Uint256):
+    end
+
+    func balanceOf(account: felt) -> (balance: Uint256):
+    end
+
+    func allowance(owner: felt, spender: felt) -> (remaining: Uint256):
+    end
+
+    func transfer(recipient: felt, amount: Uint256) -> (success: felt):
+    end
+
+    func transferFrom(
+            sender: felt, 
+            recipient: felt, 
+            amount: Uint256
+        ) -> (success: felt):
+    end
+
+    func approve(spender: felt, amount: Uint256) -> (success: felt):
+    end
+end
+

--- a/openzeppelin/src/openzeppelin/token/erc20/library.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc20/library.cairo
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.math import assert_not_zero, assert_lt
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_add, uint256_sub, uint256_le, uint256_lt, uint256_check
+)
+
+from openzeppelin.utils.constants import TRUE, FALSE, UINT8_MAX
+
+#
+# Events
+#
+
+@event
+func Transfer(from_: felt, to: felt, value: Uint256):
+end
+
+@event
+func Approval(owner: felt, spender: felt, value: Uint256):
+end
+
+#
+# Storage
+#
+
+@storage_var
+func ERC20_name_() -> (name: felt):
+end
+
+@storage_var
+func ERC20_symbol_() -> (symbol: felt):
+end
+
+@storage_var
+func ERC20_decimals_() -> (decimals: felt):
+end
+
+@storage_var
+func ERC20_total_supply() -> (total_supply: Uint256):
+end
+
+@storage_var
+func ERC20_balances(account: felt) -> (balance: Uint256):
+end
+
+@storage_var
+func ERC20_allowances(owner: felt, spender: felt) -> (allowance: Uint256):
+end
+
+#
+# Constructor
+#
+
+func ERC20_initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        decimals: felt
+    ):
+    ERC20_name_.write(name)
+    ERC20_symbol_.write(symbol)
+    with_attr error_message("ERC20: decimals exceed 2^8"):
+        assert_lt(decimals, UINT8_MAX)
+    end
+    ERC20_decimals_.write(decimals)
+    return ()
+end
+
+func ERC20_name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC20_name_.read()
+    return (name)
+end
+
+func ERC20_symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC20_symbol_.read()
+    return (symbol)
+end
+
+func ERC20_totalSupply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC20_total_supply.read()
+    return (totalSupply)
+end
+
+func ERC20_decimals{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (decimals: felt):
+    let (decimals) = ERC20_decimals_.read()
+    return (decimals)
+end
+
+func ERC20_balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC20_balances.read(account)
+    return (balance)
+end
+
+func ERC20_allowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = ERC20_allowances.read(owner, spender)
+    return (remaining)
+end
+
+func ERC20_transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256):
+    let (sender) = get_caller_address()
+    _transfer(sender, recipient, amount)
+    return ()
+end
+
+func ERC20_transferFrom{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> ():
+    alloc_locals
+    let (caller) = get_caller_address()
+    let (caller_allowance: Uint256) = ERC20_allowances.read(owner=sender, spender=caller)
+
+    let (enough_allowance) = uint256_le(amount, caller_allowance)
+    with_attr error_message("ERC20: transfer amount exceeds allowance"):
+        assert enough_allowance = TRUE
+    end
+
+    _transfer(sender, recipient, amount)
+
+    # subtract allowance
+    let (new_allowance: Uint256) = uint256_sub(caller_allowance, amount)
+    ERC20_allowances.write(sender, caller, new_allowance)
+    return ()
+end
+
+func ERC20_approve{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, amount: Uint256):
+    with_attr error_message("ERC20: amount is not a valid Uint256"):
+        uint256_check(amount)
+    end
+
+    let (caller) = get_caller_address()
+    with_attr error_message("ERC20: zero address cannot approve"):
+        assert_not_zero(caller)
+    end
+
+    with_attr error_message("ERC20: cannot approve to the zero address"):
+        assert_not_zero(spender)
+    end
+
+    ERC20_allowances.write(caller, spender, amount)
+    Approval.emit(caller, spender, amount)
+    return ()
+end
+
+func ERC20_increaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, added_value: Uint256) -> ():
+    with_attr error("ERC20: added_value is not a valid Uint256"):
+        uint256_check(added_value)
+    end
+
+    let (caller) = get_caller_address()
+    let (current_allowance: Uint256) = ERC20_allowances.read(caller, spender)
+
+    # add allowance
+    let (new_allowance: Uint256, is_overflow) = uint256_add(current_allowance, added_value)
+    with_attr error_message("ERC20: allowance overflow"):
+        assert (is_overflow) = FALSE
+    end
+
+    ERC20_approve(spender, new_allowance)
+    return ()
+end
+
+func ERC20_decreaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, subtracted_value: Uint256) -> ():
+    alloc_locals
+    with_attr error_message("ERC20: subtracted_value is not a valid Uint256"):
+        uint256_check(subtracted_value)
+    end
+
+    let (caller) = get_caller_address()
+    let (current_allowance: Uint256) = ERC20_allowances.read(owner=caller, spender=spender)
+    let (new_allowance: Uint256) = uint256_sub(current_allowance, subtracted_value)
+
+    let (enough_allowance) = uint256_lt(new_allowance, current_allowance)
+    with_attr error_message("ERC20: allowance below zero"):
+        assert enough_allowance = TRUE
+    end
+
+    ERC20_approve(spender, new_allowance)
+    return ()
+end
+
+func ERC20_mint{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256):
+    with_attr error_message("ERC20: amount is not a valid Uint256"):
+        uint256_check(amount)
+    end
+
+    with_attr error_message("ERC20: cannot mint to the zero address"):
+        assert_not_zero(recipient)
+    end
+
+    let (balance: Uint256) = ERC20_balances.read(account=recipient)
+    # overflow is not possible because sum is guaranteed to be less than total supply
+    # which we check for overflow below
+    let (new_balance, _: Uint256) = uint256_add(balance, amount)
+    ERC20_balances.write(recipient, new_balance)
+
+    let (supply: Uint256) = ERC20_total_supply.read()
+    let (new_supply: Uint256, is_overflow) = uint256_add(supply, amount)
+    with_attr error_message("ERC20: mint overflow"):
+        assert (is_overflow) = FALSE
+    end
+
+    ERC20_total_supply.write(new_supply)
+    Transfer.emit(0, recipient, amount)
+    return ()
+end
+
+func ERC20_burn{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt, amount: Uint256):
+    alloc_locals
+    with_attr error_message("ERC20: amount is not a valid Uint256"):
+        uint256_check(amount)
+    end
+
+    with_attr error_message("ERC20: cannot burn from the zero address"):
+        assert_not_zero(account)
+    end
+
+    let (balance: Uint256) = ERC20_balances.read(account)
+    let (enough_balance) = uint256_le(amount, balance)
+    with_attr error_message("ERC20: burn amount exceeds balance"):
+        assert enough_balance = TRUE
+    end
+    
+    let (new_balance: Uint256) = uint256_sub(balance, amount)
+    ERC20_balances.write(account, new_balance)
+
+    let (supply: Uint256) = ERC20_total_supply.read()
+    let (new_supply: Uint256) = uint256_sub(supply, amount)
+    ERC20_total_supply.write(new_supply)
+    Transfer.emit(account, 0, amount)
+    return ()
+end
+
+#
+# Internal
+#
+
+func _transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(sender: felt, recipient: felt, amount: Uint256):
+    alloc_locals
+    with_attr error_message("ERC20: amount is not a valid Uint256"):
+        uint256_check(amount) # almost surely not needed, might remove after confirmation
+    end
+
+    with_attr error_message("ERC20: cannot transfer from the zero address"):
+        assert_not_zero(sender)
+    end
+
+    with_attr error_message("ERC20: cannot transfer to the zero address"):
+        assert_not_zero(recipient)
+    end
+
+    let (sender_balance: Uint256) = ERC20_balances.read(account=sender)
+
+    # validates amount <= sender_balance and returns 1 if true
+    let (enough_balance) = uint256_le(amount, sender_balance)
+    with_attr error_message("ERC20: transfer amount exceeds balance"):
+        assert_not_zero(enough_balance)
+    end
+    
+    # subtract from sender
+    let (new_sender_balance: Uint256) = uint256_sub(sender_balance, amount)
+    ERC20_balances.write(sender, new_sender_balance)
+
+    # add to recipient
+    let (recipient_balance: Uint256) = ERC20_balances.read(account=recipient)
+    # overflow is not possible because sum is guaranteed by mint to be less than total supply
+    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, amount)
+    ERC20_balances.write(recipient, new_recipient_balance)
+    Transfer.emit(sender, recipient, amount)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721/ERC721_Mintable_Burnable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc721.library import (
+    ERC721_name,
+    ERC721_symbol,
+    ERC721_balanceOf,
+    ERC721_ownerOf,
+    ERC721_getApproved,
+    ERC721_isApprovedForAll,
+    ERC721_tokenURI,
+
+    ERC721_initializer,
+    ERC721_approve, 
+    ERC721_setApprovalForAll, 
+    ERC721_transferFrom,
+    ERC721_safeTransferFrom,
+    ERC721_mint,
+    ERC721_burn,
+    ERC721_only_token_owner,
+    ERC721_setTokenURI
+)
+
+from openzeppelin.introspection.ERC165 import ERC165_supports_interface
+
+from openzeppelin.access.ownable import (
+    Ownable_initializer,
+    Ownable_only_owner
+)
+
+#
+# Constructor
+#
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        owner: felt
+    ):
+    ERC721_initializer(name, symbol)
+    Ownable_initializer(owner)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func supportsInterface{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(interfaceId: felt) -> (success: felt):
+    let (success) = ERC165_supports_interface(interfaceId)
+    return (success)
+end
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC721_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC721_symbol()
+    return (symbol)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC721_balanceOf(owner)
+    return (balance)
+end
+
+@view
+func ownerOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(tokenId: Uint256) -> (owner: felt):
+    let (owner: felt) = ERC721_ownerOf(tokenId)
+    return (owner)
+end
+
+@view
+func getApproved{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(tokenId: Uint256) -> (approved: felt):
+    let (approved: felt) = ERC721_getApproved(tokenId)
+    return (approved)
+end
+
+@view
+func isApprovedForAll{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, operator: felt) -> (isApproved: felt):
+    let (isApproved: felt) = ERC721_isApprovedForAll(owner, operator)
+    return (isApproved)
+end
+
+@view
+func tokenURI{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(tokenId: Uint256) -> (tokenURI: felt):
+    let (tokenURI: felt) = ERC721_tokenURI(tokenId)
+    return (tokenURI)
+end
+
+
+#
+# Externals
+#
+
+@external
+func approve{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    ERC721_approve(to, tokenId)
+    return ()
+end
+
+@external
+func setApprovalForAll{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(operator: felt, approved: felt):
+    ERC721_setApprovalForAll(operator, approved)
+    return ()
+end
+
+@external
+func transferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256
+    ):
+    ERC721_transferFrom(from_, to, tokenId)
+    return ()
+end
+
+@external
+func safeTransferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256,
+        data_len: felt, 
+        data: felt*
+    ):
+    ERC721_safeTransferFrom(from_, to, tokenId, data_len, data)
+    return ()
+end
+
+@external
+func setTokenURI{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(tokenId: Uint256, tokenURI: felt):
+    Ownable_only_owner()
+    ERC721_setTokenURI(tokenId, tokenURI)
+    return ()
+end
+
+@external
+func mint{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    Ownable_only_owner()
+    ERC721_mint(to, tokenId)
+    return ()
+end
+
+@external
+func burn{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(tokenId: Uint256):
+    ERC721_only_token_owner(tokenId)
+    ERC721_burn(tokenId)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721/ERC721_Mintable_Pausable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc721.library import (
+    ERC721_name,
+    ERC721_symbol,
+    ERC721_balanceOf,
+    ERC721_ownerOf,
+    ERC721_getApproved,
+    ERC721_isApprovedForAll,
+    ERC721_tokenURI,
+
+    ERC721_initializer,
+    ERC721_approve, 
+    ERC721_setApprovalForAll, 
+    ERC721_transferFrom,
+    ERC721_safeTransferFrom,
+    ERC721_mint,
+    ERC721_setTokenURI
+)
+
+from openzeppelin.introspection.ERC165 import ERC165_supports_interface
+
+from openzeppelin.security.pausable import (
+    Pausable_paused,
+    Pausable_pause,
+    Pausable_unpause,
+    Pausable_when_not_paused
+)
+
+from openzeppelin.access.ownable import (
+    Ownable_initializer,
+    Ownable_only_owner
+)
+
+#
+# Constructor
+#
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        owner: felt
+    ):
+    ERC721_initializer(name, symbol)
+    Ownable_initializer(owner)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func supportsInterface{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(interfaceId: felt) -> (success: felt):
+    let (success) = ERC165_supports_interface(interfaceId)
+    return (success)
+end
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC721_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC721_symbol()
+    return (symbol)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC721_balanceOf(owner)
+    return (balance)
+end
+
+@view
+func ownerOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(tokenId: Uint256) -> (owner: felt):
+    let (owner: felt) = ERC721_ownerOf(tokenId)
+    return (owner)
+end
+
+@view
+func getApproved{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(tokenId: Uint256) -> (approved: felt):
+    let (approved: felt) = ERC721_getApproved(tokenId)
+    return (approved)
+end
+
+@view
+func isApprovedForAll{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, operator: felt) -> (isApproved: felt):
+    let (isApproved: felt) = ERC721_isApprovedForAll(owner, operator)
+    return (isApproved)
+end
+
+@view
+func tokenURI{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(tokenId: Uint256) -> (tokenURI: felt):
+    let (tokenURI: felt) = ERC721_tokenURI(tokenId)
+    return (tokenURI)
+end
+
+@view
+func paused{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (paused: felt):
+    let (paused) = Pausable_paused.read()
+    return (paused)
+end
+
+
+#
+# Externals
+#
+
+@external
+func approve{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    Pausable_when_not_paused()
+    ERC721_approve(to, tokenId)
+    return ()
+end
+
+@external
+func setApprovalForAll{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(operator: felt, approved: felt):
+    Pausable_when_not_paused()
+    ERC721_setApprovalForAll(operator, approved)
+    return ()
+end
+
+@external
+func transferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256
+    ):
+    Pausable_when_not_paused()
+    ERC721_transferFrom(from_, to, tokenId)
+    return ()
+end
+
+@external
+func safeTransferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256,
+        data_len: felt, 
+        data: felt*
+    ):
+    Pausable_when_not_paused()
+    ERC721_safeTransferFrom(from_, to, tokenId, data_len, data)
+    return ()
+end
+
+@external
+func mint{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    Pausable_when_not_paused()
+    Ownable_only_owner()
+    ERC721_mint(to, tokenId)
+    return ()
+end
+
+@external
+func setTokenURI{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(tokenId: Uint256, tokenURI: felt):
+    Ownable_only_owner()
+    ERC721_setTokenURI(tokenId, tokenURI)
+    return ()
+end
+
+@external
+func pause{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Ownable_only_owner()
+    Pausable_pause()
+    return ()
+end
+
+@external
+func unpause{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    Ownable_only_owner()
+    Pausable_unpause()
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/token/erc721/interfaces/IERC721.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721/interfaces/IERC721.cairo
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721/interfaces/IERC721.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.introspection.IERC165 import IERC165
+
+@contract_interface
+namespace IERC721:
+    func balanceOf(owner: felt) -> (balance: Uint256):
+    end
+
+    func ownerOf(tokenId: Uint256) -> (owner: felt):
+    end
+
+    func safeTransferFrom(
+            from_: felt, 
+            to: felt, 
+            tokenId: Uint256, 
+            data_len: felt,
+            data: felt*
+        ):
+    end
+
+    func transferFrom(from_: felt, to: felt, tokenId: Uint256):
+    end
+
+    func approve(approved: felt, tokenId: Uint256):
+    end
+
+    func setApprovalForAll(operator: felt, approved: felt):
+    end
+
+    func getApproved(tokenId: Uint256) -> (approved: felt):
+    end
+
+    func isApprovedForAll(owner: felt, operator: felt) -> (isApproved: felt):
+    end
+end

--- a/openzeppelin/src/openzeppelin/token/erc721/interfaces/IERC721_Metadata.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721/interfaces/IERC721_Metadata.cairo
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721/interfaces/IERC721_Metadata.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc721.interfaces.IERC721 import IERC721
+
+@contract_interface
+namespace IERC721_Metadata:
+    func name() -> (name: felt):
+    end
+
+    func symbol() -> (symbol: felt):
+    end
+
+    func tokenURI(tokenId: Uint256) -> (tokenURI: felt):
+    end
+end

--- a/openzeppelin/src/openzeppelin/token/erc721/interfaces/IERC721_Receiver.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721/interfaces/IERC721_Receiver.cairo
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721/interfaces/IERC721_Receiver.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC721_Receiver:
+    func onERC721Received(
+        operator: felt,
+        from_: felt,
+        tokenId: Uint256,
+        data_len: felt,
+        data: felt*
+    ) -> (selector: felt): 
+    end
+end

--- a/openzeppelin/src/openzeppelin/token/erc721/library.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721/library.cairo
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.math import assert_not_zero, assert_not_equal
+from starkware.cairo.common.alloc import alloc
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.uint256 import Uint256, uint256_check
+
+from openzeppelin.security.safemath import (
+    uint256_checked_add,
+    uint256_checked_sub_le
+)
+
+from openzeppelin.introspection.ERC165 import ERC165_register_interface
+
+from openzeppelin.token.erc721.interfaces.IERC721_Receiver import IERC721_Receiver
+
+from openzeppelin.introspection.IERC165 import IERC165
+
+from openzeppelin.utils.constants import (
+    TRUE, FALSE, IERC721_ID, IERC721_METADATA_ID, IERC721_RECEIVER_ID, IACCOUNT_ID
+)
+
+#
+# Events
+#
+
+@event
+func Transfer(from_: felt, to: felt, tokenId: Uint256):
+end
+
+@event
+func Approval(owner: felt, approved: felt, tokenId: Uint256):
+end
+
+@event
+func ApprovalForAll(owner: felt, operator: felt, approved: felt):
+end
+
+#
+# Storage
+#
+
+@storage_var
+func ERC721_name_() -> (name: felt):
+end
+
+@storage_var
+func ERC721_symbol_() -> (symbol: felt):
+end
+
+@storage_var
+func ERC721_owners(token_id: Uint256) -> (owner: felt):
+end
+
+@storage_var
+func ERC721_balances(account: felt) -> (balance: Uint256):
+end
+
+@storage_var
+func ERC721_token_approvals(token_id: Uint256) -> (res: felt):
+end
+
+@storage_var
+func ERC721_operator_approvals(owner: felt, operator: felt) -> (res: felt):
+end
+
+@storage_var
+func ERC721_token_uri(token_id: Uint256) -> (token_uri: felt):
+end
+
+#
+# Constructor
+#
+
+func ERC721_initializer{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+    ):
+    ERC721_name_.write(name)
+    ERC721_symbol_.write(symbol)
+    ERC165_register_interface(IERC721_ID)
+    ERC165_register_interface(IERC721_METADATA_ID)
+    return ()
+end
+
+#
+# Getters
+#
+
+func ERC721_name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC721_name_.read()
+    return (name)
+end
+
+func ERC721_symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC721_symbol_.read()
+    return (symbol)
+end
+
+func ERC721_balanceOf{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt) -> (balance: Uint256):
+    with_attr error_message("ERC721: balance query for the zero address"):
+        assert_not_zero(owner)
+    end
+    let (balance: Uint256) = ERC721_balances.read(owner)
+    return (balance)
+end
+
+func ERC721_ownerOf{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(token_id: Uint256) -> (owner: felt):
+    with_attr error_message("ERC721: token_id is not a valid Uint256"):
+        uint256_check(token_id)
+    end
+    let (owner) = ERC721_owners.read(token_id)
+    with_attr error_message("ERC721: owner query for nonexistent token"):
+        assert_not_zero(owner)
+    end
+    return (owner)
+end
+
+func ERC721_getApproved{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(token_id: Uint256) -> (approved: felt):
+    with_attr error_message("ERC721: token_id is not a valid Uint256"):
+        uint256_check(token_id)
+    end
+    let (exists) = _exists(token_id)
+    with_attr error_message("ERC721: approved query for nonexistent token"):
+        assert exists = TRUE
+    end
+
+    let (approved) = ERC721_token_approvals.read(token_id)
+    return (approved)
+end
+
+func ERC721_isApprovedForAll{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, operator: felt) -> (is_approved: felt):
+    let (is_approved) = ERC721_operator_approvals.read(owner=owner, operator=operator)
+    return (is_approved)
+end
+
+func ERC721_tokenURI{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(token_id: Uint256) -> (token_uri: felt):
+    let (exists) = _exists(token_id)
+    with_attr error_message("ERC721_Metadata: URI query for nonexistent token"):
+        assert exists = TRUE
+    end
+
+    # if tokenURI is not set, it will return 0
+    let (token_uri) = ERC721_token_uri.read(token_id)
+    return (token_uri)
+end
+
+#
+# Externals
+#
+
+func ERC721_approve{
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
+        range_check_ptr
+    }(to: felt, token_id: Uint256):
+    with_attr error_mesage("ERC721: token_id is not a valid Uint256"):
+        uint256_check(token_id)
+    end
+
+    # Checks caller is not zero address
+    let (caller) = get_caller_address()
+    with_attr error_message("ERC721: cannot approve from the zero address"):
+        assert_not_zero(caller)
+    end
+
+    # Ensures 'owner' does not equal 'to'
+    let (owner) = ERC721_owners.read(token_id)
+    with_attr error_message("ERC721: approval to current owner"):
+        assert_not_equal(owner, to)
+    end
+
+    # Checks that either caller equals owner or
+    # caller isApprovedForAll on behalf of owner
+    if caller == owner:
+        _approve(to, token_id)
+        return ()
+    else:
+        let (is_approved) = ERC721_operator_approvals.read(owner, caller)
+        with_attr error_message("ERC721: approve caller is not owner nor approved for all"):
+            assert_not_zero(is_approved)
+        end
+        _approve(to, token_id)
+        return ()
+    end
+end
+
+func ERC721_setApprovalForAll{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(operator: felt, approved: felt):
+    # Ensures caller is neither zero address nor operator
+    let (caller) = get_caller_address()
+    with_attr error_message("ERC721: either the caller or operator is the zero address"):
+        assert_not_zero(caller * operator)
+    end
+    # note this pattern as we'll frequently use it:
+    #   instead of making an `assert_not_zero` call for each address
+    #   we can always briefly write `assert_not_zero(a0 * a1 * ... * aN)`.
+    #   This is because these addresses are field elements,
+    #   meaning that a*0==0 for all a in the field,
+    #   and a*b==0 implies that at least one of a,b are zero in the field
+    with_attr error_message("ERC721: approve to caller"):
+        assert_not_equal(caller, operator)
+    end
+
+    # Make sure `approved` is a boolean (0 or 1)
+    with_attr error_message("ERC721: approved is not a Cairo boolean"):
+        assert approved * (1 - approved) = 0
+    end
+
+    ERC721_operator_approvals.write(owner=caller, operator=operator, value=approved)
+    ApprovalForAll.emit(caller, operator, approved)
+    return ()
+end
+
+func ERC721_transferFrom{
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
+        range_check_ptr
+    }(from_: felt, to: felt, token_id: Uint256):
+    alloc_locals
+    with_attr error_message("ERC721: token_id is not a valid Uint256"):
+        uint256_check(token_id)
+    end
+    let (caller) = get_caller_address()
+    let (is_approved) = _is_approved_or_owner(caller, token_id)
+    with_attr error_message("ERC721: either is not approved or the caller is the zero address"):
+        assert_not_zero(caller * is_approved)
+    end
+    # Note that if either `is_approved` or `caller` equals `0`,
+    # then this method should fail.
+    # The `caller` address and `is_approved` boolean are both field elements
+    # meaning that a*0==0 for all a in the field,
+    # therefore a*b==0 implies that at least one of a,b is zero in the field
+
+    _transfer(from_, to, token_id)
+    return ()
+end
+
+func ERC721_safeTransferFrom{
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
+        range_check_ptr
+    }(
+        from_: felt,
+        to: felt,
+        token_id: Uint256,
+        data_len: felt,
+        data: felt*
+    ):
+    alloc_locals
+    with_attr error_message("ERC721: token_id is not a valid Uint256"):
+        uint256_check(token_id)
+    end
+    let (caller) = get_caller_address()
+    let (is_approved) = _is_approved_or_owner(caller, token_id)
+    with_attr error_message("ERC721: either is not approved or the caller is the zero address"):
+        assert_not_zero(caller * is_approved)
+    end
+    # Note that if either `is_approved` or `caller` equals `0`,
+    # then this method should fail.
+    # The `caller` address and `is_approved` boolean are both field elements
+    # meaning that a*0==0 for all a in the field,
+    # therefore a*b==0 implies that at least one of a,b is zero in the field
+
+    _safe_transfer(from_, to, token_id, data_len, data)
+    return ()
+end
+
+func ERC721_mint{
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
+        range_check_ptr
+    }(to: felt, token_id: Uint256):
+    with_attr error_message("ERC721: token_id is not a valid Uint256"):
+        uint256_check(token_id)
+    end
+    with_attr error_message("ERC721: cannot mint to the zero address"):
+        assert_not_zero(to)
+    end
+
+    # Ensures token_id is unique
+    let (exists) = _exists(token_id)
+    with_attr error_message("ERC721: token already minted"):
+        assert exists = FALSE
+    end
+
+    let (balance: Uint256) = ERC721_balances.read(to)
+    let (new_balance: Uint256) = uint256_checked_add(balance, Uint256(1, 0))
+    ERC721_balances.write(to, new_balance)
+    ERC721_owners.write(token_id, to)
+    Transfer.emit(0, to, token_id)
+    return ()
+end
+
+func ERC721_burn{
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
+        range_check_ptr
+    }(token_id: Uint256):
+    alloc_locals
+    with_attr error_message("ERC721: token_id is not a valid Uint256"):
+        uint256_check(token_id)
+    end
+    let (owner) = ERC721_ownerOf(token_id)
+
+    # Clear approvals
+    _approve(0, token_id)
+
+    # Decrease owner balance
+    let (balance: Uint256) = ERC721_balances.read(owner)
+    let (new_balance: Uint256) = uint256_checked_sub_le(balance, Uint256(1, 0))
+    ERC721_balances.write(owner, new_balance)
+
+    # Delete owner
+    ERC721_owners.write(token_id, 0)
+    Transfer.emit(owner, 0, token_id)
+    return ()
+end
+
+func ERC721_safeMint{
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
+        range_check_ptr
+    }(
+        to: felt,
+        token_id: Uint256,
+        data_len: felt,
+        data: felt*
+    ):
+    with_attr error_message("ERC721: token_id is not a valid Uint256"):
+        uint256_check(token_id)
+    end
+    ERC721_mint(to, token_id)
+
+    let (success) = _check_onERC721Received(
+        0,
+        to,
+        token_id,
+        data_len,
+        data
+    )
+    with_attr error_message("ERC721: transfer to non ERC721Receiver implementer"):
+        assert_not_zero(success)
+    end
+    return ()
+end
+
+func ERC721_only_token_owner{
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
+        range_check_ptr
+    }(token_id: Uint256):
+    uint256_check(token_id)
+    let (caller) = get_caller_address()
+    let (owner) = ERC721_ownerOf(token_id)
+    # Note `ERC721_ownerOf` checks that the owner is not the zero address
+    with_attr error_message("ERC721: caller is not the token owner"):
+        assert caller = owner
+    end
+    return ()
+end
+
+func ERC721_setTokenURI{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(token_id: Uint256, token_uri: felt):
+    uint256_check(token_id)
+    let (exists) = _exists(token_id)
+    with_attr error_message("ERC721_Metadata: set token URI for nonexistent token"):
+        assert exists = TRUE
+    end
+
+    ERC721_token_uri.write(token_id, token_uri)
+    return ()
+end
+
+#
+# Internals
+#
+
+func _approve{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(to: felt, token_id: Uint256):
+    ERC721_token_approvals.write(token_id, to)
+    let (owner) = ERC721_ownerOf(token_id)
+    Approval.emit(owner, to, token_id)
+    return ()
+end
+
+func _is_approved_or_owner{
+        pedersen_ptr: HashBuiltin*,
+        syscall_ptr: felt*,
+        range_check_ptr
+    }(spender: felt, token_id: Uint256) -> (res: felt):
+    alloc_locals
+
+    let (exists) = _exists(token_id)
+    with_attr error_message("ERC721: token id does not exist"):
+        assert exists = TRUE
+    end
+
+    let (owner) = ERC721_ownerOf(token_id)
+    if owner == spender:
+        return (TRUE)
+    end
+
+    let (approved_addr) = ERC721_getApproved(token_id)
+    if approved_addr == spender:
+        return (TRUE)
+    end
+
+    let (is_operator) = ERC721_isApprovedForAll(owner, spender)
+    if is_operator == TRUE:
+        return (TRUE)
+    end
+
+    return (FALSE)
+end
+
+func _exists{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(token_id: Uint256) -> (res: felt):
+    let (res) = ERC721_owners.read(token_id)
+
+    if res == 0:
+        return (FALSE)
+    else:
+        return (TRUE)
+    end
+end
+
+func _transfer{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(from_: felt, to: felt, token_id: Uint256):
+    # ownerOf ensures 'from_' is not the zero address
+    let (_ownerOf) = ERC721_ownerOf(token_id)
+    with_attr error_message("ERC721: transfer from incorrect owner"):
+        assert _ownerOf = from_
+    end
+
+    with_attr error_message("ERC721: cannot transfer to the zero address"):
+        assert_not_zero(to)
+    end
+
+    # Clear approvals
+    _approve(0, token_id)
+
+    # Decrease owner balance
+    let (owner_bal) = ERC721_balances.read(from_)
+    let (new_balance: Uint256) = uint256_checked_sub_le(owner_bal, Uint256(1, 0))
+    ERC721_balances.write(from_, new_balance)
+
+    # Increase receiver balance
+    let (receiver_bal) = ERC721_balances.read(to)
+    let (new_balance: Uint256) = uint256_checked_add(receiver_bal, Uint256(1, 0))
+    ERC721_balances.write(to, new_balance)
+
+    # Update token_id owner
+    ERC721_owners.write(token_id, to)
+    Transfer.emit(from_, to, token_id)
+    return ()
+end
+
+func _safe_transfer{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        from_: felt,
+        to: felt,
+        token_id: Uint256,
+        data_len: felt,
+        data: felt*
+    ):
+    _transfer(from_, to, token_id)
+
+    let (success) = _check_onERC721Received(from_, to, token_id, data_len, data)
+    with_attr error_message("ERC721: transfer to non ERC721Receiver implementer"):
+        assert_not_zero(success)
+    end
+    return ()
+end
+
+func _check_onERC721Received{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        from_: felt,
+        to: felt,
+        token_id: Uint256,
+        data_len: felt,
+        data: felt*
+    ) -> (success: felt):
+    let (caller) = get_caller_address()
+    let (is_supported) = IERC165.supportsInterface(to, IERC721_RECEIVER_ID)
+    if is_supported == TRUE:
+        let (selector) = IERC721_Receiver.onERC721Received(
+            to,
+            caller,
+            from_,
+            token_id,
+            data_len,
+            data
+        )
+
+        with_attr error_message("ERC721: transfer to non ERC721Receiver implementer"):
+            assert selector = IERC721_RECEIVER_ID
+        end
+        return (TRUE)
+    end
+
+    let (is_account) = IERC165.supportsInterface(to, IACCOUNT_ID)
+    return (is_account)
+end

--- a/openzeppelin/src/openzeppelin/token/erc721/utils/ERC721_Holder.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721/utils/ERC721_Holder.cairo
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721/utils/ERC721_Holder.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.utils.constants import IERC721_RECEIVER_ID
+
+from openzeppelin.introspection.ERC165 import (
+    ERC165_supports_interface,
+    ERC165_register_interface
+)
+
+@view
+func onERC721Received(
+        operator: felt,
+        from_: felt,
+        tokenId: Uint256,
+        data_len: felt,
+        data: felt*
+    ) -> (selector: felt): 
+    return (IERC721_RECEIVER_ID)
+end
+
+@view
+func supportsInterface{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(interfaceId: felt) -> (success: felt):
+    let (success) = ERC165_supports_interface(interfaceId)
+    return (success)
+end
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }():
+    ERC165_register_interface(IERC721_RECEIVER_ID)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc721.library import (
+    ERC721_name,
+    ERC721_symbol,
+    ERC721_balanceOf,
+    ERC721_ownerOf,
+    ERC721_getApproved,
+    ERC721_isApprovedForAll,
+    ERC721_tokenURI,
+
+    ERC721_initializer,
+    ERC721_approve, 
+    ERC721_setApprovalForAll,
+    ERC721_only_token_owner,
+    ERC721_setTokenURI
+)
+
+from openzeppelin.token.erc721_enumerable.library import (
+    ERC721_Enumerable_initializer,
+    ERC721_Enumerable_totalSupply,
+    ERC721_Enumerable_tokenByIndex,
+    ERC721_Enumerable_tokenOfOwnerByIndex,
+    ERC721_Enumerable_mint,
+    ERC721_Enumerable_burn,
+    ERC721_Enumerable_transferFrom,
+    ERC721_Enumerable_safeTransferFrom
+)
+
+from openzeppelin.introspection.ERC165 import ERC165_supports_interface
+
+from openzeppelin.access.ownable import (
+    Ownable_initializer,
+    Ownable_only_owner
+)
+
+#
+# Constructor
+#
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        owner: felt
+    ):
+    ERC721_initializer(name, symbol)
+    ERC721_Enumerable_initializer()
+    Ownable_initializer(owner)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func totalSupply{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC721_Enumerable_totalSupply()
+    return (totalSupply)
+end
+
+@view
+func tokenByIndex{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(index: Uint256) -> (tokenId: Uint256):
+    let (tokenId: Uint256) = ERC721_Enumerable_tokenByIndex(index)
+    return (tokenId)
+end
+
+@view
+func tokenOfOwnerByIndex{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(owner: felt, index: Uint256) -> (tokenId: Uint256):
+    let (tokenId: Uint256) = ERC721_Enumerable_tokenOfOwnerByIndex(owner, index)
+    return (tokenId)
+end
+
+@view
+func supportsInterface{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(interfaceId: felt) -> (success: felt):
+    let (success) = ERC165_supports_interface(interfaceId)
+    return (success)
+end
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC721_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC721_symbol()
+    return (symbol)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC721_balanceOf(owner)
+    return (balance)
+end
+
+@view
+func ownerOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(tokenId: Uint256) -> (owner: felt):
+    let (owner: felt) = ERC721_ownerOf(tokenId)
+    return (owner)
+end
+
+@view
+func getApproved{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(tokenId: Uint256) -> (approved: felt):
+    let (approved: felt) = ERC721_getApproved(tokenId)
+    return (approved)
+end
+
+@view
+func isApprovedForAll{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, operator: felt) -> (isApproved: felt):
+    let (isApproved: felt) = ERC721_isApprovedForAll(owner, operator)
+    return (isApproved)
+end
+
+@view
+func tokenURI{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(tokenId: Uint256) -> (tokenURI: felt):
+    let (tokenURI: felt) = ERC721_tokenURI(tokenId)
+    return (tokenURI)
+end
+
+#
+# Externals
+#
+
+@external
+func approve{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    ERC721_approve(to, tokenId)
+    return ()
+end
+
+@external
+func setApprovalForAll{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(operator: felt, approved: felt):
+    ERC721_setApprovalForAll(operator, approved)
+    return ()
+end
+
+@external
+func transferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256
+    ):
+    ERC721_Enumerable_transferFrom(from_, to, tokenId)
+    return ()
+end
+
+@external
+func safeTransferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256, 
+        data_len: felt,
+        data: felt*
+    ):
+    ERC721_Enumerable_safeTransferFrom(from_, to, tokenId, data_len, data)
+    return ()
+end
+
+@external
+func mint{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    Ownable_only_owner()
+    ERC721_Enumerable_mint(to, tokenId)
+    return ()
+end
+
+@external
+func burn{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(tokenId: Uint256):
+    ERC721_only_token_owner(tokenId)
+    ERC721_Enumerable_burn(tokenId)
+    return ()
+end
+
+@external
+func setTokenURI{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(tokenId: Uint256, tokenURI: felt):
+    Ownable_only_owner()
+    ERC721_setTokenURI(tokenId, tokenURI)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/token/erc721_enumerable/interfaces/IERC721_Enumerable.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721_enumerable/interfaces/IERC721_Enumerable.cairo
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721_enumerable/interfaces/IERC721_Enumerable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc721.interfaces.IERC721 import IERC721
+
+@contract_interface
+namespace IERC721_Enumerable:
+    func totalSupply() -> (totalSupply: Uint256):
+    end
+
+    func tokenByIndex(index: Uint256) -> (tokenId: Uint256):
+    end
+
+    func tokenOfOwnerByIndex(owner: felt, index: Uint256) -> (tokenId: Uint256):
+    end
+end

--- a/openzeppelin/src/openzeppelin/token/erc721_enumerable/library.cairo
+++ b/openzeppelin/src/openzeppelin/token/erc721_enumerable/library.cairo
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (token/erc721_enumerable/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.math import assert_not_equal
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.uint256 import (
+    Uint256, uint256_add, uint256_sub, uint256_lt, uint256_eq, uint256_check
+)
+
+from openzeppelin.token.erc721.library import (
+    ERC721_balanceOf,
+    ERC721_ownerOf,
+
+    ERC721_transferFrom,
+    ERC721_safeTransferFrom,
+    ERC721_mint,
+    ERC721_burn
+)
+
+from openzeppelin.introspection.ERC165 import ERC165_register_interface
+
+from openzeppelin.utils.constants import TRUE, IERC721_ENUMERABLE_ID
+
+#
+# Storage
+#
+
+@storage_var
+func ERC721_Enumerable_all_tokens_len() -> (res: Uint256):
+end
+
+@storage_var
+func ERC721_Enumerable_all_tokens(index: Uint256) -> (token_id: Uint256):
+end
+
+@storage_var
+func ERC721_Enumerable_all_tokens_index(token_id: Uint256) -> (index: Uint256):
+end
+
+@storage_var
+func ERC721_Enumerable_owned_tokens(owner: felt, index: Uint256) -> (token_id: Uint256):
+end
+
+@storage_var
+func ERC721_Enumerable_owned_tokens_index(token_id: Uint256) -> (index: Uint256):
+end
+
+#
+# Constructor
+#
+
+func ERC721_Enumerable_initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }():
+    ERC165_register_interface(IERC721_ENUMERABLE_ID)
+    return ()
+end
+
+#
+# Getters
+#
+
+func ERC721_Enumerable_totalSupply{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply) = ERC721_Enumerable_all_tokens_len.read()
+    return (totalSupply)
+end
+
+
+func ERC721_Enumerable_tokenByIndex{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(index: Uint256) -> (token_id: Uint256):
+    alloc_locals
+    uint256_check(index)
+    # Ensures index argument is less than total_supply 
+    let (len: Uint256) = ERC721_Enumerable_totalSupply()
+    let (is_lt) = uint256_lt(index, len)
+    with_attr error_message("ERC721_Enumerable: global index out of bounds"):
+        assert is_lt = TRUE
+    end
+
+    let (token_id: Uint256) = ERC721_Enumerable_all_tokens.read(index)
+    return (token_id)
+end
+
+func ERC721_Enumerable_tokenOfOwnerByIndex{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(owner: felt, index: Uint256) -> (token_id: Uint256):
+    alloc_locals
+    uint256_check(index)
+    # Ensures index argument is less than owner's balance 
+    let (len: Uint256) = ERC721_balanceOf(owner)
+    let (is_lt) = uint256_lt(index, len)
+    with_attr error_message("ERC721_Enumerable: owner index out of bounds"):
+        assert is_lt = TRUE
+    end
+    
+    let (token_id: Uint256) = ERC721_Enumerable_owned_tokens.read(owner, index)
+    return (token_id)
+end
+
+#
+# Externals
+#
+
+func ERC721_Enumerable_mint{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, token_id: Uint256):
+    _add_token_to_all_tokens_enumeration(token_id)
+    _add_token_to_owner_enumeration(to, token_id)
+    ERC721_mint(to, token_id)
+    return ()
+end
+
+func ERC721_Enumerable_burn{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(token_id: Uint256):
+    let (from_) = ERC721_ownerOf(token_id)
+    _remove_token_from_owner_enumeration(from_, token_id)
+    _remove_token_from_all_tokens_enumeration(token_id)
+    ERC721_burn(token_id)
+    return ()
+end
+
+func ERC721_Enumerable_transferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(from_: felt, to: felt, token_id: Uint256):
+    _remove_token_from_owner_enumeration(from_, token_id)
+    _add_token_to_owner_enumeration(to, token_id)
+    ERC721_transferFrom(from_, to, token_id)
+    return ()
+end
+
+func ERC721_Enumerable_safeTransferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        token_id: Uint256, 
+        data_len: felt,
+        data: felt*
+    ):
+    _remove_token_from_owner_enumeration(from_, token_id)
+    _add_token_to_owner_enumeration(to, token_id)
+    ERC721_safeTransferFrom(from_, to, token_id, data_len, data)
+    return ()
+end
+
+#
+# Internals
+#
+
+func _add_token_to_all_tokens_enumeration{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(token_id: Uint256):
+    let (supply: Uint256) = ERC721_Enumerable_all_tokens_len.read()
+    ERC721_Enumerable_all_tokens.write(supply, token_id)
+    ERC721_Enumerable_all_tokens_index.write(token_id, supply)
+    
+    let (new_supply: Uint256, _) = uint256_add(supply, Uint256(1, 0))
+    ERC721_Enumerable_all_tokens_len.write(new_supply)
+    return ()
+end
+
+
+func _remove_token_from_all_tokens_enumeration{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(token_id: Uint256):
+    let (supply: Uint256) = ERC721_Enumerable_all_tokens_len.read()
+    let (last_token_index: Uint256) = uint256_sub(supply, Uint256(1, 0))
+    let (token_index: Uint256) = ERC721_Enumerable_all_tokens_index.read(token_id)
+
+    # When the token to delete is the last token, the swap operation is unnecessary. However,
+    # since this occurs so rarely (when the last minted token is burnt), we still do the swap
+    # here to avoid the gas cost of adding an 'if' statement (like in _remove_token_from_owner_enumeration)
+    let (last_token_id: Uint256) = ERC721_Enumerable_all_tokens.read(last_token_index)
+
+    ERC721_Enumerable_all_tokens.write(last_token_index, Uint256(0, 0))
+    ERC721_Enumerable_all_tokens.write(token_index, last_token_id)
+
+    ERC721_Enumerable_all_tokens_index.write(last_token_id, token_index)
+    ERC721_Enumerable_all_tokens_index.write(token_id, Uint256(0, 0))
+
+    let (new_supply: Uint256) = uint256_sub(supply, Uint256(1, 0))
+    ERC721_Enumerable_all_tokens_len.write(new_supply)
+    return ()
+end
+
+func _add_token_to_owner_enumeration{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, token_id: Uint256):
+    let (length: Uint256) = ERC721_balanceOf(to) 
+    ERC721_Enumerable_owned_tokens.write(to, length, token_id)
+    ERC721_Enumerable_owned_tokens_index.write(token_id, length)
+    return ()
+end
+
+func _remove_token_from_owner_enumeration{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(from_: felt, token_id: Uint256):
+    alloc_locals
+    let (last_token_index: Uint256) = ERC721_balanceOf(from_)
+    # the index starts at zero therefore the user's last token index is their balance minus one
+    let (last_token_index) = uint256_sub(last_token_index, Uint256(1, 0))
+    let (token_index: Uint256) = ERC721_Enumerable_owned_tokens_index.read(token_id)
+
+    # If index is last, we can just set the return values to zero
+    let (is_equal) = uint256_eq(token_index, last_token_index)
+    if is_equal == TRUE:
+        ERC721_Enumerable_owned_tokens_index.write(token_id, Uint256(0, 0))
+        ERC721_Enumerable_owned_tokens.write(from_, last_token_index, Uint256(0, 0))
+        return ()
+    end
+
+    # If index is not last, reposition owner's last token to the removed token's index
+    let (last_token_id: Uint256) = ERC721_Enumerable_owned_tokens.read(from_, last_token_index)
+    ERC721_Enumerable_owned_tokens.write(from_, token_index, last_token_id)
+    ERC721_Enumerable_owned_tokens_index.write(last_token_id, token_index)
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/upgrades/Proxy.cairo
+++ b/openzeppelin/src/openzeppelin/upgrades/Proxy.cairo
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (upgrades/Proxy.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import delegate_l1_handler, delegate_call
+from openzeppelin.upgrades.library import (
+    Proxy_implementation_address,
+    Proxy_set_implementation
+)
+
+#
+# Constructor
+#
+
+@constructor
+func constructor{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(implementation_address: felt):
+    Proxy_set_implementation(implementation_address)
+    return ()
+end
+
+#
+# Fallback functions
+#
+
+@external
+@raw_input
+@raw_output
+func __default__{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        selector: felt,
+        calldata_size: felt,
+        calldata: felt*
+    ) -> (
+        retdata_size: felt,
+        retdata: felt*
+    ):
+    let (address) = Proxy_implementation_address.read()
+
+    let (retdata_size: felt, retdata: felt*) = delegate_call(
+        contract_address=address,
+        function_selector=selector,
+        calldata_size=calldata_size,
+        calldata=calldata
+    )
+
+    return (retdata_size=retdata_size, retdata=retdata)
+end
+
+@l1_handler
+@raw_input
+func __l1_default__{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        selector: felt,
+        calldata_size: felt,
+        calldata: felt*
+    ):
+    let (address) = Proxy_implementation_address.read()
+
+    delegate_l1_handler(
+        contract_address=address,
+        function_selector=selector,
+        calldata_size=calldata_size,
+        calldata=calldata
+    )
+
+    return ()
+end

--- a/openzeppelin/src/openzeppelin/upgrades/library.cairo
+++ b/openzeppelin/src/openzeppelin/upgrades/library.cairo
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (upgrades/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from openzeppelin.utils.constants import TRUE, FALSE
+
+#
+# Events
+#
+
+@event
+func Upgraded(implementation: felt):
+end
+
+#
+# Storage variables
+#
+
+@storage_var
+func Proxy_implementation_address() -> (implementation_address: felt):
+end
+
+@storage_var
+func Proxy_admin() -> (proxy_admin: felt):
+end
+
+@storage_var
+func Proxy_initialized() -> (initialized: felt):
+end
+
+#
+# Initializer
+#
+
+func Proxy_initializer{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(proxy_admin: felt):
+    let (initialized) = Proxy_initialized.read()
+    with_attr error_message("Proxy: contract already initialized"):
+        assert initialized = FALSE
+    end
+
+    Proxy_initialized.write(TRUE)
+    Proxy_admin.write(proxy_admin)
+    return ()
+end
+
+#
+# Upgrades
+#
+
+func Proxy_set_implementation{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_implementation: felt):
+    Proxy_implementation_address.write(new_implementation)
+    Upgraded.emit(new_implementation)
+    return ()
+end
+
+#
+# Guards
+#
+
+func Proxy_only_admin{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }():
+    let (caller) = get_caller_address()
+    let (admin) = Proxy_admin.read()
+    with_attr error_message("Proxy: caller is not admin"):
+        assert admin = caller
+    end
+    return ()
+end
+
+#
+# Getters
+#
+
+func Proxy_get_admin{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (admin: felt):
+    let (admin) = Proxy_admin.read()
+    return (admin)
+end 
+
+func Proxy_get_implementation{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (implementation: felt):
+    let (implementation) = Proxy_implementation_address.read()
+    return (implementation)
+end 
+
+#
+# Setters
+#
+
+func Proxy_set_admin{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_admin: felt):
+    Proxy_admin.write(new_admin)
+    return ()
+end 

--- a/openzeppelin/src/openzeppelin/utils/constants.cairo
+++ b/openzeppelin/src/openzeppelin/utils/constants.cairo
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# OpenZeppelin Cairo Contracts v0.1.0 (utils/constants.cairo)
+
+%lang starknet
+
+#
+# Booleans
+#
+
+const TRUE = 1
+const FALSE = 0
+
+#
+# Numbers
+#
+
+const UINT8_MAX = 256
+
+#
+# Interface Ids
+#
+
+# ERC165
+const IERC165_ID = 0x01ffc9a7
+const INVALID_ID = 0xffffffff
+
+# Account
+const IACCOUNT_ID = 0xf10dbd44
+
+# ERC721
+const IERC721_ID = 0x80ac58cd
+const IERC721_RECEIVER_ID = 0x150b7a02
+const IERC721_METADATA_ID = 0x5b5e139f
+const IERC721_ENUMERABLE_ID = 0x780e9d63

--- a/openzeppelin/tests/access/test_Ownable.py
+++ b/openzeppelin/tests/access/test_Ownable.py
@@ -1,0 +1,37 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import Signer, contract_path
+
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+async def ownable_factory():
+    starknet = await Starknet.empty()
+    owner = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+
+    ownable = await starknet.deploy(
+        contract_path("tests/mocks/Ownable.cairo"),
+        constructor_calldata=[owner.contract_address]
+    )
+    return starknet, ownable, owner
+
+
+@pytest.mark.asyncio
+async def test_constructor(ownable_factory):
+    _, ownable, owner = ownable_factory
+    expected = await ownable.get_owner().call()
+    assert expected.result.owner == owner.contract_address
+
+
+@pytest.mark.asyncio
+async def test_transfer_ownership(ownable_factory):
+    _, ownable, owner = ownable_factory
+    new_owner = 123
+    await signer.send_transaction(owner, ownable.contract_address, 'transfer_ownership', [new_owner])
+    executed_info = await ownable.get_owner().call()
+    assert executed_info.result == (new_owner,)

--- a/openzeppelin/tests/account/test_Account.py
+++ b/openzeppelin/tests/account/test_Account.py
@@ -1,0 +1,158 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from starkware.starkware_utils.error_handling import StarkException
+from starkware.starknet.definitions.error_codes import StarknetErrorCode
+from utils import Signer, assert_revert, contract_path
+
+
+signer = Signer(123456789987654321)
+other = Signer(987654321123456789)
+
+IACCOUNT_ID = 0xf10dbd44
+TRUE = 1
+
+
+@pytest.fixture(scope='module')
+async def account_factory():
+    starknet = await Starknet.empty()
+    account = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+    bad_account = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key],
+    )
+
+    return starknet, account, bad_account
+
+
+@pytest.mark.asyncio
+async def test_constructor(account_factory):
+    _, account, _ = account_factory
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (signer.public_key,)
+
+    execution_info = await account.supportsInterface(IACCOUNT_ID).call()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_execute(account_factory):
+    starknet, account, _ = account_factory
+    initializable = await starknet.deploy(
+        contract_path("openzeppelin/security/initializable.cairo")
+    )
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (0,)
+
+    await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])])
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (1,)
+
+
+@pytest.mark.asyncio
+async def test_multicall(account_factory):
+    starknet, account, _ = account_factory
+    initializable_1 = await starknet.deploy(
+        contract_path("openzeppelin/security/initializable.cairo")
+    )
+    initializable_2 = await starknet.deploy(
+        contract_path("openzeppelin/security/initializable.cairo")
+    )
+
+    execution_info = await initializable_1.initialized().call()
+    assert execution_info.result == (0,)
+    execution_info = await initializable_2.initialized().call()
+    assert execution_info.result == (0,)
+
+    await signer.send_transactions(
+        account,
+        [
+            (initializable_1.contract_address, 'initialize', []),
+            (initializable_2.contract_address, 'initialize', [])
+        ]
+    )
+
+    execution_info = await initializable_1.initialized().call()
+    assert execution_info.result == (1,)
+    execution_info = await initializable_2.initialized().call()
+    assert execution_info.result == (1,)
+
+
+@pytest.mark.asyncio
+async def test_return_value(account_factory):
+    starknet, account, _ = account_factory
+    initializable = await starknet.deploy(
+        contract_path("openzeppelin/security/initializable.cairo")
+    )
+
+    # initialize, set `initialized = 1`
+    await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])])
+
+    read_info = await signer.send_transactions(account, [(initializable.contract_address, 'initialized', [])])
+    call_info = await initializable.initialized().call()
+    (call_result, ) = call_info.result
+    assert read_info.result.response == [call_result]  # 1
+
+
+@ pytest.mark.asyncio
+async def test_nonce(account_factory):
+    starknet, account, _ = account_factory
+    initializable = await starknet.deploy(
+        contract_path("openzeppelin/security/initializable.cairo")
+    )
+    execution_info = await account.get_nonce().call()
+    current_nonce = execution_info.result.res
+
+    # lower nonce
+    try:
+        await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], current_nonce - 1)
+        assert False
+    except StarkException as err:
+        _, error = err.args
+        assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
+
+    # higher nonce
+    try:
+        await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], current_nonce + 1)
+        assert False
+    except StarkException as err:
+        _, error = err.args
+        assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
+    # right nonce
+    await signer.send_transactions(account, [(initializable.contract_address, 'initialize', [])], current_nonce)
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (1,)
+
+
+@pytest.mark.asyncio
+async def test_public_key_setter(account_factory):
+    _, account, _ = account_factory
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (signer.public_key,)
+
+    # set new pubkey
+    await signer.send_transactions(account, [(account.contract_address, 'set_public_key', [other.public_key])])
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (other.public_key,)
+
+
+@pytest.mark.asyncio
+async def test_public_key_setter_different_account(account_factory):
+    _, account, bad_account = account_factory
+
+    # set new pubkey
+    await assert_revert(
+        signer.send_transactions(
+            bad_account,
+            [(account.contract_address, 'set_public_key', [other.public_key])]
+        ),
+        reverted_with="Account: caller is not this account"
+    )

--- a/openzeppelin/tests/account/test_AddressRegistry.py
+++ b/openzeppelin/tests/account/test_AddressRegistry.py
@@ -1,0 +1,47 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import Signer, contract_path
+
+
+signer = Signer(123456789987654321)
+L1_ADDRESS = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
+ANOTHER_ADDRESS = 0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f
+
+
+@pytest.fixture(scope='module')
+async def account_factory():
+    starknet = await Starknet.empty()
+    registry = await starknet.deploy(
+        contract_path("openzeppelin/account/AddressRegistry.cairo")
+    )
+    account = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+
+    return starknet, account, registry
+
+
+@pytest.mark.asyncio
+async def test_set_address(account_factory):
+    _, account, registry = account_factory
+
+    await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (L1_ADDRESS,)
+
+
+@pytest.mark.asyncio
+async def test_update_address(account_factory):
+    _, account, registry = account_factory
+
+    await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
+
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (L1_ADDRESS,)
+
+    # set new address
+    await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [ANOTHER_ADDRESS])
+
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (ANOTHER_ADDRESS,)

--- a/openzeppelin/tests/conftest.py
+++ b/openzeppelin/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+import asyncio
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()

--- a/openzeppelin/tests/introspection/test_ERC165.py
+++ b/openzeppelin/tests/introspection/test_ERC165.py
@@ -1,0 +1,58 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import assert_revert, contract_path
+
+
+# interface ids
+ERC165_ID = 0x01ffc9a7
+INVALID_ID = 0xffffffff
+OTHER_ID = 0x12345678
+
+
+@pytest.fixture(scope='module')
+async def erc165_factory():
+    starknet = await Starknet.empty()
+    contract = await starknet.deploy(
+        contract_path("tests/mocks/ERC165.cairo")
+    )
+    return contract
+
+
+@pytest.mark.asyncio
+async def test_165_interface(erc165_factory):
+    contract = erc165_factory
+
+    execution_info = await contract.supportsInterface(ERC165_ID).call()
+    assert execution_info.result == (1,)
+
+
+@pytest.mark.asyncio
+async def test_invalid_id(erc165_factory):
+    contract = erc165_factory
+
+    execution_info = await contract.supportsInterface(INVALID_ID).call()
+    assert execution_info.result == (0,)
+
+
+@pytest.mark.asyncio
+async def test_register_interface(erc165_factory):
+    contract = erc165_factory
+
+    execution_info = await contract.supportsInterface(OTHER_ID).call()
+    assert execution_info.result == (0,)
+
+    # register interface
+    await contract.registerInterface(OTHER_ID).invoke()
+
+    execution_info = await contract.supportsInterface(OTHER_ID).call()
+    assert execution_info.result == (1,)
+
+
+@pytest.mark.asyncio
+async def test_register_invalid_interface(erc165_factory):
+    contract = erc165_factory
+
+    await assert_revert(
+        contract.registerInterface(INVALID_ID).invoke(),
+        reverted_with="ERC165: invalid interface id"
+    )

--- a/openzeppelin/tests/mocks/ERC165.cairo
+++ b/openzeppelin/tests/mocks/ERC165.cairo
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+
+from openzeppelin.introspection.ERC165 import (
+    ERC165_supports_interface, 
+    ERC165_register_interface
+)
+
+@view
+func supportsInterface{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (interfaceId: felt) -> (success: felt):
+    let (success) = ERC165_supports_interface(interfaceId)
+    return (success)
+end
+
+@external
+func registerInterface{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (interfaceId: felt):
+    ERC165_register_interface(interfaceId)
+    return ()
+end

--- a/openzeppelin/tests/mocks/ERC20_Burnable_mock.cairo
+++ b/openzeppelin/tests/mocks/ERC20_Burnable_mock.cairo
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.utils.constants import TRUE
+
+from openzeppelin.token.erc20.library import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom,
+    ERC20_mint,
+    ERC20_burn
+)
+
+@constructor
+func constructor{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        decimals: felt,
+        initial_supply: Uint256,
+        recipient: felt
+    ):
+    ERC20_initializer(name, symbol, decimals)
+    ERC20_mint(recipient, initial_supply)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC20_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC20_symbol()
+    return (symbol)
+end
+
+@view
+func totalSupply{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (totalSupply: Uint256):
+    let (totalSupply: Uint256) = ERC20_totalSupply()
+    return (totalSupply)
+end
+
+@view
+func decimals{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (decimals: felt):
+    let (decimals) = ERC20_decimals()
+    return (decimals)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(account: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC20_balanceOf(account)
+    return (balance)
+end
+
+@view
+func allowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, spender: felt) -> (remaining: Uint256):
+    let (remaining: Uint256) = ERC20_allowance(owner, spender)
+    return (remaining)
+end
+
+#
+# Externals
+#
+
+@external
+func transfer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(recipient: felt, amount: Uint256) -> (success: felt):
+    ERC20_transfer(recipient, amount)
+    return (TRUE)
+end
+
+@external
+func transferFrom{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        sender: felt, 
+        recipient: felt, 
+        amount: Uint256
+    ) -> (success: felt):
+    ERC20_transferFrom(sender, recipient, amount)
+    return (TRUE)
+end
+
+@external
+func approve{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, amount: Uint256) -> (success: felt):
+    ERC20_approve(spender, amount)
+    return (TRUE)
+end
+
+@external
+func increaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, added_value: Uint256) -> (success: felt):
+    ERC20_increaseAllowance(spender, added_value)
+    return (TRUE)
+end
+
+@external
+func decreaseAllowance{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(spender: felt, subtracted_value: Uint256) -> (success: felt):
+    ERC20_decreaseAllowance(spender, subtracted_value)
+    return (TRUE)
+end
+
+@external
+func burn{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(amount: Uint256):
+    let (owner) = get_caller_address()
+    ERC20_burn(owner, amount)
+    return ()
+end

--- a/openzeppelin/tests/mocks/ERC721_SafeMintable_mock.cairo
+++ b/openzeppelin/tests/mocks/ERC721_SafeMintable_mock.cairo
@@ -1,0 +1,225 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc721.library import (
+    ERC721_name,
+    ERC721_symbol,
+    ERC721_balanceOf,
+    ERC721_ownerOf,
+    ERC721_getApproved,
+    ERC721_isApprovedForAll,
+    ERC721_tokenURI,
+
+    ERC721_initializer,
+    ERC721_approve, 
+    ERC721_setApprovalForAll, 
+    ERC721_transferFrom,
+    ERC721_safeTransferFrom,
+    ERC721_mint,
+    ERC721_safeMint,
+    ERC721_setTokenURI
+)
+
+from openzeppelin.introspection.ERC165 import ERC165_supports_interface
+
+from openzeppelin.access.ownable import (
+    Ownable_initializer,
+    Ownable_only_owner
+)
+
+#
+# Constructor
+#
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        name: felt,
+        symbol: felt,
+        owner: felt
+    ):
+    ERC721_initializer(name, symbol)
+    Ownable_initializer(owner)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func supportsInterface{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(interfaceId: felt) -> (success: felt):
+    let (success) = ERC165_supports_interface(interfaceId)
+    return (success)
+end
+
+@view
+func name{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (name: felt):
+    let (name) = ERC721_name()
+    return (name)
+end
+
+@view
+func symbol{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (symbol: felt):
+    let (symbol) = ERC721_symbol()
+    return (symbol)
+end
+
+@view
+func balanceOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt) -> (balance: Uint256):
+    let (balance: Uint256) = ERC721_balanceOf(owner)
+    return (balance)
+end
+
+@view
+func ownerOf{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(tokenId: Uint256) -> (owner: felt):
+    let (owner: felt) = ERC721_ownerOf(tokenId)
+    return (owner)
+end
+
+@view
+func getApproved{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(tokenId: Uint256) -> (approved: felt):
+    let (approved: felt) = ERC721_getApproved(tokenId)
+    return (approved)
+end
+
+@view
+func isApprovedForAll{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt, operator: felt) -> (isApproved: felt):
+    let (isApproved: felt) = ERC721_isApprovedForAll(owner, operator)
+    return (isApproved)
+end
+
+@view
+func tokenURI{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(tokenId: Uint256) -> (tokenURI: felt):
+    let (tokenURI: felt) = ERC721_tokenURI(tokenId)
+    return (tokenURI)
+end
+
+#
+# Externals
+#
+
+@external
+func approve{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    ERC721_approve(to, tokenId)
+    return ()
+end
+
+@external
+func setApprovalForAll{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    }(operator: felt, approved: felt):
+    ERC721_setApprovalForAll(operator, approved)
+    return ()
+end
+
+@external
+func transferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256
+    ):
+    ERC721_transferFrom(from_, to, tokenId)
+    return ()
+end
+
+@external
+func safeTransferFrom{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        from_: felt, 
+        to: felt, 
+        tokenId: Uint256,
+        data_len: felt, 
+        data: felt*
+    ):
+    ERC721_safeTransferFrom(from_, to, tokenId, data_len, data)
+    return ()
+end
+
+@external
+func mint{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(to: felt, tokenId: Uint256):
+    Ownable_only_owner()
+    ERC721_mint(to, tokenId)
+    return ()
+end
+
+@external
+func safeMint{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(
+        to: felt,
+        tokenId: Uint256,
+        data_len: felt,
+        data: felt*
+    ):
+    Ownable_only_owner()
+    ERC721_safeMint(to, tokenId, data_len, data)
+    return ()
+end
+
+@external
+func setTokenURI{
+        pedersen_ptr: HashBuiltin*, 
+        syscall_ptr: felt*, 
+        range_check_ptr
+    }(tokenId: Uint256, tokenURI: felt):
+    Ownable_only_owner()
+    ERC721_setTokenURI(tokenId, tokenURI)
+    return ()
+end

--- a/openzeppelin/tests/mocks/Ownable.cairo
+++ b/openzeppelin/tests/mocks/Ownable.cairo
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from openzeppelin.access.ownable import (
+    Ownable_initializer,
+    Ownable_get_owner,
+    Ownable_transfer_ownership
+)
+
+@constructor
+func constructor{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(owner: felt):
+    Ownable_initializer(owner)
+    return ()
+end
+
+@external
+func get_owner{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (owner: felt):
+    let (owner) = Ownable_get_owner()
+    return (owner=owner)
+end
+
+@external
+func transfer_ownership{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_owner: felt) -> (new_owner: felt):
+    Ownable_transfer_ownership(new_owner)
+    return (new_owner=new_owner)
+end

--- a/openzeppelin/tests/mocks/proxiable_implementation.cairo
+++ b/openzeppelin/tests/mocks/proxiable_implementation.cairo
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MIT
+
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.upgrades.library import (
+    Proxy_initializer,
+    Proxy_get_implementation
+)
+
+#
+# Storage
+#
+
+@storage_var
+func value() -> (res: felt):
+end
+
+#
+# Initializer
+#
+
+@external
+func initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(proxy_admin: felt):
+    Proxy_initializer(proxy_admin)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func get_value{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (val: felt):
+    let (val) = value.read()
+    return (val)
+end
+
+@view
+func get_implementation{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (address: felt):
+    let (address) = Proxy_get_implementation()
+    return (address)
+end
+
+#
+# Setters
+#
+
+@external
+func set_value{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(val: felt):
+    value.write(val)
+    return ()
+end

--- a/openzeppelin/tests/mocks/safemath_mock.cairo
+++ b/openzeppelin/tests/mocks/safemath_mock.cairo
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.security.safemath import (
+    uint256_checked_add,
+    uint256_checked_sub_le,
+    uint256_checked_sub_lt,
+    uint256_checked_mul,
+    uint256_checked_div_rem
+)
+
+#
+# Note the follow exposed functions are meant for testing.
+# Contracts should import from the `safemath.cairo` library.
+#
+
+@view
+func test_add{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256):
+    let (c: Uint256) = uint256_checked_add(a, b)
+    return (c)
+end
+
+@view
+func test_sub_le{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256):
+    let (c: Uint256) = uint256_checked_sub_le(a, b)
+    return (c)
+end
+
+@view
+func test_sub_lt{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256):
+    let (c: Uint256) = uint256_checked_sub_lt(a, b)
+    return (c)
+end
+
+@view
+func test_mul{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256):
+    let (c: Uint256) = uint256_checked_mul(a, b)
+    return (c)
+end
+
+@view
+func test_div{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*, 
+        range_check_ptr
+    } (a: Uint256, b: Uint256) -> (c: Uint256, rem: Uint256):
+    let (c: Uint256, rem: Uint256) = uint256_checked_div_rem(a, b)
+    return (c, rem)
+end

--- a/openzeppelin/tests/mocks/upgrades_v1_mock.cairo
+++ b/openzeppelin/tests/mocks/upgrades_v1_mock.cairo
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.upgrades.library import (
+    Proxy_initializer,
+    Proxy_only_admin,
+    Proxy_set_implementation
+)
+
+#
+# Storage
+#
+
+@storage_var
+func value_1() -> (res: felt):
+end
+
+#
+# Initializer
+#
+
+@external
+func initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(proxy_admin: felt):
+    Proxy_initializer(proxy_admin)
+    return ()
+end
+
+#
+# Upgrades
+#
+
+@external
+func upgrade{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_implementation: felt):
+    Proxy_only_admin()
+    Proxy_set_implementation(new_implementation)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func get_value_1{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (val: felt):
+    let (val) = value_1.read()
+    return (val)
+end
+
+#
+# Setters
+#
+
+@external
+func set_value_1{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(val: felt):
+    value_1.write(val)
+    return ()
+end

--- a/openzeppelin/tests/mocks/upgrades_v2_mock.cairo
+++ b/openzeppelin/tests/mocks/upgrades_v2_mock.cairo
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: MIT
+
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.upgrades.library import (
+    Proxy_initializer,
+    Proxy_only_admin,
+    Proxy_set_implementation,
+    Proxy_get_implementation,
+    Proxy_set_admin,
+    Proxy_get_admin
+)
+
+#
+# Storage
+#
+
+@storage_var
+func value_1() -> (res: felt):
+end
+
+@storage_var
+func value_2() -> (res: felt):
+end
+
+#
+# Initializer
+#
+
+@external
+func initializer{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(proxy_admin: felt):
+    Proxy_initializer(proxy_admin)
+    return ()
+end
+
+#
+# Upgrades
+#
+
+@external
+func upgrade{
+        syscall_ptr: felt*, 
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }(new_implementation: felt):
+    Proxy_only_admin()
+    Proxy_set_implementation(new_implementation)
+    return ()
+end
+
+#
+# Getters
+#
+
+@view
+func get_value_1{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (val: felt):
+    let (val) = value_1.read()
+    return (val)
+end
+
+@view
+func get_value_2{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (val: felt):
+    let (val) = value_2.read()
+    return (val)
+end
+
+@view
+func get_implementation{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (address: felt):
+    let (address) = Proxy_get_implementation()
+    return (address)
+end
+
+@view
+func get_admin{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (admin: felt):
+    let (admin) = Proxy_get_admin()
+    return (admin)
+end
+
+#
+# Setters
+#
+
+@external
+func set_value_1{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(val: felt):
+    value_1.write(val)
+    return ()
+end
+
+@external
+func set_value_2{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(val: felt):
+    value_2.write(val)
+    return ()
+end
+
+@view
+func set_admin{
+        syscall_ptr : felt*, 
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(new_admin: felt):
+    Proxy_only_admin()
+    Proxy_set_admin(new_admin)
+    return ()
+end

--- a/openzeppelin/tests/security/test_initializable.py
+++ b/openzeppelin/tests/security/test_initializable.py
@@ -1,0 +1,24 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import TRUE, FALSE, assert_revert, contract_path
+
+
+@pytest.mark.asyncio
+async def test_initializer():
+    starknet = await Starknet.empty()
+    initializable = await starknet.deploy(
+        contract_path("openzeppelin/security/initializable.cairo")
+    )
+    expected = await initializable.initialized().call()
+    assert expected.result == (FALSE,)
+
+    await initializable.initialize().invoke()
+
+    expected = await initializable.initialized().call()
+    assert expected.result == (TRUE,)
+
+    # second initialize invocation should revert
+    await assert_revert(
+        initializable.initialize().invoke(),
+        reverted_with="Initializable: contract already initialized"
+    )

--- a/openzeppelin/tests/security/test_safemath.py
+++ b/openzeppelin/tests/security/test_safemath.py
@@ -1,0 +1,206 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    MAX_UINT256, assert_revert, add_uint, sub_uint,
+    mul_uint, div_rem_uint, to_uint, contract_path
+)
+
+
+@pytest.fixture(scope='module')
+async def safemath_mock():
+    starknet = await Starknet.empty()
+    safemath = await starknet.deploy(
+        contract_path("tests/mocks/safemath_mock.cairo")
+    )
+
+    return safemath
+
+
+@pytest.mark.asyncio
+async def test_add(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(1234)
+    c = add_uint(a, b)
+
+    execution_info = await safemath.test_add(a, b).invoke()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_add_overflow(safemath_mock):
+    safemath = safemath_mock
+
+    a = MAX_UINT256
+    b = to_uint(1)
+
+    await assert_revert(
+        safemath.test_add(a, b).invoke(),
+        reverted_with="Safemath: addition overflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_lt(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(1234)
+    c = sub_uint(a, b)
+
+    execution_info = await safemath.test_sub_lt(a, b).invoke()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_sub_lt_equal(safemath_mock):
+    safemath = safemath_mock
+
+    a = MAX_UINT256
+    b = MAX_UINT256
+
+    await assert_revert(
+        safemath.test_sub_lt(a, b).invoke(),
+        reverted_with="Safemath: subtraction overflow or the difference equals zero"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_lt_overflow(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(1234)
+    b = to_uint(56789)
+
+    await assert_revert(
+        safemath.test_sub_lt(a, b).invoke(),
+        reverted_with="Safemath: subtraction overflow or the difference equals zero"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_le(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(1234)
+    c = sub_uint(a, b)
+
+    execution_info = await safemath.test_sub_le(a, b).invoke()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_sub_le_equal(safemath_mock):
+    safemath = safemath_mock
+
+    a = MAX_UINT256
+    b = MAX_UINT256
+    c = sub_uint(a, b)
+
+    execution_info = await safemath.test_sub_le(a, b).invoke()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_sub_le_overflow(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(1234)
+    b = to_uint(56789)
+
+    await assert_revert(
+        safemath.test_sub_le(a, b).invoke(),
+        reverted_with="Safemath: subtraction overflow"
+    )
+    await assert_revert(safemath.test_sub_le(a, b).invoke())
+
+
+@pytest.mark.asyncio
+async def test_mul(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(1234)
+    b = to_uint(56789)
+    c = mul_uint(a, b)
+
+    execution_info = await safemath.test_mul(a, b).invoke()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_mul_zero(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(0)
+    b = to_uint(56789)
+    c = to_uint(0)
+
+    execution_info = await safemath.test_mul(a, b).invoke()
+    assert execution_info.result == (c,)
+
+    execution_info = await safemath.test_mul(b, a).invoke()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_mul_overflow(safemath_mock):
+    safemath = safemath_mock
+
+    a = MAX_UINT256
+    b = to_uint(2)
+
+    await assert_revert(
+        safemath.test_mul(a, b).invoke(),
+        reverted_with="Safemath: multiplication overflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_div(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(56789)
+    (c, r) = div_rem_uint(a, b)
+
+    execution_info = await safemath.test_div(a, b).invoke()
+    assert execution_info.result == (c, r)
+
+
+@pytest.mark.asyncio
+async def test_div_zero_dividend(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(0)
+    b = to_uint(56789)
+    (c, r) = div_rem_uint(a, b)
+
+    execution_info = await safemath.test_div(a, b).invoke()
+    assert execution_info.result == (c, r)
+
+
+@pytest.mark.asyncio
+async def test_div_zero_divisor(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(0)
+
+    await assert_revert(
+        safemath.test_div(a, b).invoke(),
+        reverted_with="Safemath: divisor cannot be zero"
+    )
+
+
+@pytest.mark.asyncio
+async def test_div_uneven_division(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(7000)
+    b = to_uint(5678)
+    (c, r) = div_rem_uint(a, b)
+
+    execution_info = await safemath.test_div(a, b).invoke()
+    assert execution_info.result == (c, r)

--- a/openzeppelin/tests/token/erc20/test_ERC20.py
+++ b/openzeppelin/tests/token/erc20/test_ERC20.py
@@ -1,0 +1,585 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, uint, str_to_felt, MAX_UINT256, INVALID_UINT256, ZERO_ADDRESS,
+    assert_event_emitted, assert_revert, sub_uint, add_uint, contract_path
+)
+
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+async def erc20_factory():
+    starknet = await Starknet.empty()
+    account = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+
+    erc20 = await starknet.deploy(
+        contract_path("openzeppelin/token/erc20/ERC20.cairo"),
+        constructor_calldata=[
+            str_to_felt("Token"),      # name
+            str_to_felt("TKN"),        # symbol
+            18,                        # decimals
+            *uint(1000),               # initial_supply
+            account.contract_address   # recipient
+        ]
+    )
+    return starknet, erc20, account
+
+
+@pytest.mark.asyncio
+async def test_constructor(erc20_factory):
+    _, erc20, account = erc20_factory
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    assert execution_info.result.balance == uint(1000)
+
+    execution_info = await erc20.totalSupply().call()
+    assert execution_info.result.totalSupply == uint(1000)
+
+
+@pytest.mark.asyncio
+async def test_constructor_invalid_decimals(erc20_factory):
+    starknet, _, account = erc20_factory
+    invalid_decimals = 2**8 + 1
+
+    await assert_revert(starknet.deploy(
+        contract_path("openzeppelin/token/erc20/ERC20.cairo"),
+        constructor_calldata=[
+            str_to_felt("Token"),
+            str_to_felt("TKN"),
+            invalid_decimals,
+            *uint(1000),
+            account.contract_address
+        ]),
+        reverted_with="ERC20: decimals exceed 2^8"
+    )
+
+
+@pytest.mark.asyncio
+async def test_name(erc20_factory):
+    _, erc20, _ = erc20_factory
+    execution_info = await erc20.name().call()
+    assert execution_info.result == (str_to_felt("Token"),)
+
+
+@pytest.mark.asyncio
+async def test_symbol(erc20_factory):
+    _, erc20, _ = erc20_factory
+    execution_info = await erc20.symbol().call()
+    assert execution_info.result == (str_to_felt("TKN"),)
+
+
+@pytest.mark.asyncio
+async def test_decimals(erc20_factory):
+    _, erc20, _ = erc20_factory
+    execution_info = await erc20.decimals().call()
+    assert execution_info.result.decimals == 18
+
+
+@pytest.mark.asyncio
+async def test_transfer(erc20_factory):
+    _, erc20, account = erc20_factory
+    recipient = 123
+    amount = uint(100)
+    execution_info = await erc20.totalSupply().call()
+    previous_supply = execution_info.result.totalSupply
+
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    assert execution_info.result.balance == uint(1000)
+
+    execution_info = await erc20.balanceOf(recipient).call()
+    assert execution_info.result.balance == uint(0)
+
+    # transfer
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, *amount])
+    # check return value equals true ('1')
+    assert return_bool.result.response == [1]
+
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    assert execution_info.result.balance == uint(900)
+
+    execution_info = await erc20.balanceOf(recipient).call()
+    assert execution_info.result.balance == uint(100)
+
+    execution_info = await erc20.totalSupply().call()
+    assert execution_info.result.totalSupply == previous_supply
+
+
+@pytest.mark.asyncio
+async def test_transfer_emits_event(erc20_factory):
+    _, erc20, account = erc20_factory
+    recipient = 123
+    amount = uint(100)
+
+    tx_exec_info = await signer.send_transaction(
+        account, erc20.contract_address, 'transfer', [
+            recipient,
+            *amount
+        ])
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            recipient,
+            *amount
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_insufficient_sender_funds(erc20_factory):
+    _, erc20, account = erc20_factory
+    recipient = 123
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    balance = execution_info.result.balance
+
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'transfer', [
+            recipient,
+            *uint(balance[0] + 1)
+        ]),
+        reverted_with="ERC20: transfer amount exceeds balance"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_invalid_uint256(erc20_factory):
+    _, erc20, account = erc20_factory
+    recipient = 123
+
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'transfer', [
+            recipient,
+            *INVALID_UINT256
+        ]),
+        reverted_with="ERC20: amount is not a valid Uint256"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve(erc20_factory):
+    _, erc20, account = erc20_factory
+    spender = 123
+    amount = uint(345)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == uint(0)
+
+    # set approval
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
+    # check return value equals true ('1')
+    assert return_bool.result.response == [1]
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == amount
+
+
+@pytest.mark.asyncio
+async def test_approve_emits_event(erc20_factory):
+    _, erc20, account = erc20_factory
+    spender = 123
+    amount = uint(345)
+
+    tx_exec_info = await signer.send_transaction(
+        account, erc20.contract_address, 'approve', [
+            spender,
+            *amount
+        ])
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            spender,
+            *amount
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_invalid_uint256(erc20_factory):
+    _, erc20, account = erc20_factory
+    spender = 123
+
+    await assert_revert(
+        signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender,
+                *INVALID_UINT256
+            ]),
+        reverted_with="ERC20: amount is not a valid Uint256"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transferFrom(erc20_factory):
+    starknet, erc20, account = erc20_factory
+    spender = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+    # we use the same signer to control the main and the spender accounts
+    # this is ok since they're still two different accounts
+    amount = uint(345)
+    recipient = 987
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    previous_balance = execution_info.result.balance
+
+    # approve
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
+    # transferFrom
+    return_bool = await signer.send_transaction(
+        spender, erc20.contract_address, 'transferFrom', [
+            account.contract_address, recipient, *amount])
+    # check return value equals true ('1')
+    assert return_bool.result.response == [1]
+
+    execution_info = await erc20.balanceOf(account.contract_address).call()
+    assert execution_info.result.balance == (
+        uint(previous_balance[0] - amount[0])
+    )
+
+    execution_info = await erc20.balanceOf(recipient).call()
+    assert execution_info.result.balance == amount
+
+    execution_info = await erc20.allowance(account.contract_address, spender.contract_address).call()
+    assert execution_info.result.remaining == uint(0)
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_emits_event(erc20_factory):
+    starknet, erc20, account = erc20_factory
+    spender = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+    amount = uint(345)
+    recipient = 987
+
+    # approve
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
+    # transferFrom
+    tx_exec_info = await signer.send_transaction(
+        spender, erc20.contract_address, 'transferFrom', [
+            account.contract_address,
+            recipient,
+            *amount
+        ])
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            recipient,
+            *amount
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_increaseAllowance(erc20_factory):
+    _, erc20, account = erc20_factory
+    # new spender, starting from zero
+    spender = 234
+    amount = uint(345)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == uint(0)
+
+    # set approve
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == amount
+
+    # increase allowance
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'increaseAllowance', [spender, *amount])
+    # check return value equals true ('1')
+    assert return_bool.result.response == [1]
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == (
+        uint(amount[0] * 2)
+    )
+
+
+@pytest.mark.asyncio
+async def test_increaseAllowance_emits_event(erc20_factory):
+    _, erc20, account = erc20_factory
+    # new spender, starting from zero
+    spender = 234
+    amount = uint(345)
+
+    # set approve
+    await signer.send_transaction(
+        account, erc20.contract_address, 'approve', [
+            spender, *amount
+        ])
+
+    # increase allowance
+    tx_exec_info = await signer.send_transaction(
+        account, erc20.contract_address, 'increaseAllowance', [
+            spender,
+            *amount
+        ])
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            spender,
+            *add_uint(amount, amount)
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_decreaseAllowance(erc20_factory):
+    _, erc20, account = erc20_factory
+    # new spender, starting from zero
+    spender = 321
+    init_amount = uint(345)
+    subtract_amount = uint(100)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == uint(0)
+
+    # set approve
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *init_amount])
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == init_amount
+
+    # decrease allowance
+    return_bool = await signer.send_transaction(account, erc20.contract_address, 'decreaseAllowance', [spender, *subtract_amount])
+    # check return value equals true ('1')
+    assert return_bool.result.response == [1]
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == (
+        uint(init_amount[0] - subtract_amount[0])
+    )
+
+
+@pytest.mark.asyncio
+async def test_decreaseAllowance_emits_event(erc20_factory):
+    _, erc20, account = erc20_factory
+    # new spender, starting from zero
+    spender = 321
+    init_amount = uint(345)
+    subtract_amount = uint(100)
+
+    # set approve
+    await signer.send_transaction(
+        account, erc20.contract_address, 'approve', [
+            spender,
+            *init_amount
+        ])
+
+    # decrease allowance
+    tx_exec_info = await signer.send_transaction(
+        account, erc20.contract_address, 'decreaseAllowance', [
+            spender,
+            *subtract_amount
+        ])
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            spender,
+            *sub_uint(init_amount, subtract_amount)
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_decreaseAllowance_emits_event(erc20_factory):
+    _, erc20, account = erc20_factory
+
+    spender = 321
+
+    await assert_revert(
+        signer.send_transaction(
+            account, erc20.contract_address, 'decreaseAllowance', [
+                spender,
+                *INVALID_UINT256
+            ]),
+        reverted_with="ERC20: subtracted_value is not a valid Uint256"
+    )
+
+
+@pytest.mark.asyncio
+async def test_decreaseAllowance_overflow(erc20_factory):
+    _, erc20, account = erc20_factory
+    # new spender, starting from zero
+    spender = 987
+    init_amount = uint(345)
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *init_amount])
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result.remaining == init_amount
+
+    # increasing the decreased allowance amount by more than the user's allowance
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'decreaseAllowance', [
+            spender,
+            *uint(init_amount[0] + 1)
+        ]),
+        reverted_with="ERC20: allowance below zero"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_funds_greater_than_allowance(erc20_factory):
+    starknet, erc20, account = erc20_factory
+    spender = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+    # we use the same signer to control the main and the spender accounts
+    # this is ok since they're still two different accounts
+    recipient = 222
+    allowance = uint(111)
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *allowance])
+
+    # increasing the transfer amount above allowance
+    await assert_revert(signer.send_transaction(
+        spender, erc20.contract_address, 'transferFrom', [
+            account.contract_address,
+            recipient,
+            *uint(allowance[0] + 1)
+        ]),
+        reverted_with="ERC20: transfer amount exceeds allowance"
+    )
+
+
+@pytest.mark.asyncio
+async def test_increaseAllowance_overflow(erc20_factory):
+    _, erc20, account = erc20_factory
+    # new spender, starting from zero
+    spender = 234
+    amount = MAX_UINT256
+    # overflow_amount adds (1, 0) to (2**128 - 1, 2**128 - 1)
+    overflow_amount = uint(1)
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, *amount])
+
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'increaseAllowance', [
+            spender, *overflow_amount
+        ]),
+        reverted_with="ERC20: allowance overflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_to_zero_address(erc20_factory):
+    _, erc20, account = erc20_factory
+    amount = uint(1)
+
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'transfer', [
+            ZERO_ADDRESS, *amount
+        ]),
+        reverted_with="ERC20: cannot transfer to the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_zero_address(erc20_factory):
+    _, erc20, _ = erc20_factory
+    recipient = 123
+    amount = uint(1)
+
+    # Without using an account abstraction, the caller address
+    # (get_caller_address) is zero
+    await assert_revert(
+        erc20.transfer(recipient, amount).invoke(),
+        reverted_with="ERC20: cannot transfer from the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_func_to_zero_address(erc20_factory):
+    starknet, erc20, account = erc20_factory
+    spender = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+    # we use the same signer to control the main and the spender accounts
+    # this is ok since they're still two different accounts
+    amount = uint(1)
+
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *amount])
+
+    await assert_revert(signer.send_transaction(
+        spender, erc20.contract_address, 'transferFrom', [
+            account.contract_address,
+            ZERO_ADDRESS,
+            *amount
+        ]),
+        reverted_with="ERC20: cannot transfer to the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_func_from_zero_address(erc20_factory):
+    starknet, erc20, _ = erc20_factory
+    spender = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+    # we use the same signer to control the main and the spender accounts
+    # this is ok since they're still two different accounts
+    recipient = 123
+    amount = uint(1)
+
+    await assert_revert(signer.send_transaction(
+        spender, erc20.contract_address, 'transferFrom', [
+            ZERO_ADDRESS,
+            recipient,
+            *amount
+        ]),
+        reverted_with="ERC20: transfer amount exceeds allowance"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_zero_address_spender(erc20_factory):
+    _, erc20, account = erc20_factory
+    amount = uint(1)
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'approve', [
+            ZERO_ADDRESS,
+            *amount
+        ]),
+        reverted_with="ERC20: cannot approve to the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_zero_address_caller(erc20_factory):
+    _, erc20, _ = erc20_factory
+    spender = 123
+    amount = uint(345)
+
+    # Without using an account abstraction, the caller address
+    # (get_caller_address) is zero
+    await assert_revert(
+        erc20.approve(spender, amount).invoke(),
+        reverted_with="ERC20: zero address cannot approve"
+    )

--- a/openzeppelin/tests/token/erc20/test_ERC20_Burnable_mock.py
+++ b/openzeppelin/tests/token/erc20/test_ERC20_Burnable_mock.py
@@ -1,0 +1,110 @@
+import pytest
+import asyncio
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, to_uint, str_to_felt, ZERO_ADDRESS, INVALID_UINT256,
+    assert_event_emitted, assert_revert, sub_uint, add_uint,
+    contract_path
+)
+
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+async def erc20_factory():
+    starknet = await Starknet.empty()
+    account = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+
+    erc20 = await starknet.deploy(
+        contract_path("tests/mocks/ERC20_Burnable_mock.cairo"),
+        constructor_calldata=[
+            str_to_felt("Token"),      # name
+            str_to_felt("TKN"),        # symbol
+            18,                        # decimals
+            *to_uint(1000),            # initial_supply
+            account.contract_address   # recipient
+        ]
+    )
+    return starknet, erc20, account
+
+
+@pytest.mark.asyncio
+async def test_burn(erc20_factory):
+    _, erc20, account = erc20_factory
+    amount = to_uint(100)
+
+    execution_info = await erc20.balanceOf(account.contract_address).invoke()
+    init_balance = execution_info.result.balance
+
+    await signer.send_transaction(
+        account, erc20.contract_address, 'burn', [
+            *amount
+        ])
+
+    execution_info = await erc20.balanceOf(account.contract_address).invoke()
+    new_balance = execution_info.result.balance
+
+    assert sub_uint(init_balance, amount) == new_balance
+
+
+@pytest.mark.asyncio
+async def test_burn_emits_event(erc20_factory):
+    _, erc20, account = erc20_factory
+    amount = to_uint(100)
+
+    tx_exec_info = await signer.send_transaction(
+        account, erc20.contract_address, 'burn', [
+            *amount
+        ])
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            ZERO_ADDRESS,
+            *amount
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_not_enough_balance(erc20_factory):
+    _, erc20, account = erc20_factory
+
+    execution_info = await erc20.balanceOf(account.contract_address).invoke()
+    amount = execution_info.result.balance
+
+    await assert_revert(signer.send_transaction(
+        account, erc20.contract_address, 'burn', [
+            *add_uint(amount, to_uint(1))
+        ]),
+        reverted_with="ERC20: burn amount exceeds balance"
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_from_zero_address(erc20_factory):
+    _, erc20, _ = erc20_factory
+    amount = to_uint(1)
+
+    await assert_revert(
+        erc20.burn(amount).invoke(),
+        reverted_with="ERC20: cannot burn from the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_invalid_uint256(erc20_factory):
+    _, erc20, _ = erc20_factory
+
+    await assert_revert(
+        erc20.burn(INVALID_UINT256).invoke(),
+        reverted_with="ERC20: amount is not a valid Uint256"
+    )

--- a/openzeppelin/tests/token/erc20/test_ERC20_Mintable.py
+++ b/openzeppelin/tests/token/erc20/test_ERC20_Mintable.py
@@ -1,0 +1,147 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256,
+    assert_revert, assert_event_emitted, contract_path
+)
+
+signer = Signer(123456789987654321)
+
+# random address
+RECIPIENT = 789
+
+
+@pytest.fixture(scope='module')
+async def token_factory():
+    starknet = await Starknet.empty()
+    owner = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+
+    token = await starknet.deploy(
+        contract_path("openzeppelin/token/erc20/ERC20_Mintable.cairo"),
+        constructor_calldata=[
+            str_to_felt("Mintable Token"),
+            str_to_felt("MTKN"),
+            18,
+            *uint(1000),
+            owner.contract_address,
+            owner.contract_address
+        ]
+    )
+    return starknet, token, owner
+
+
+@pytest.mark.asyncio
+async def test_constructor(token_factory):
+    _, token, owner = token_factory
+
+    execution_info = await token.name().invoke()
+    assert execution_info.result == (str_to_felt("Mintable Token"),)
+
+    execution_info = await token.symbol().invoke()
+    assert execution_info.result == (str_to_felt("MTKN"),)
+
+    execution_info = await token.decimals().invoke()
+    assert execution_info.result.decimals == 18
+
+    execution_info = await token.balanceOf(owner.contract_address).invoke()
+    assert execution_info.result.balance == uint(1000)
+
+
+@pytest.mark.asyncio
+async def test_mint(token_factory):
+    _, erc20, account = token_factory
+    amount = uint(1)
+
+    await signer.send_transaction(account, erc20.contract_address, 'mint', [account.contract_address, *amount])
+
+    # check new supply
+    execution_info = await erc20.totalSupply().invoke()
+    new_supply = execution_info.result.totalSupply
+    assert new_supply == uint(1001)
+
+
+@pytest.mark.asyncio
+async def test_mint_emits_event(token_factory):
+    _, erc20, account = token_factory
+    amount = uint(1)
+
+    tx_exec_info = await signer.send_transaction(
+        account, erc20.contract_address, 'mint', [
+            account.contract_address,
+            *amount
+        ])
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc20.contract_address,
+        name='Transfer',
+        data=[
+            ZERO_ADDRESS,
+            account.contract_address,
+            *amount
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_mint_to_zero_address(token_factory):
+    _, erc20, account = token_factory
+    amount = uint(1)
+
+    await assert_revert(signer.send_transaction(
+        account,
+        erc20.contract_address,
+        'mint',
+        [ZERO_ADDRESS, *amount]),
+        reverted_with="ERC20: cannot mint to the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mint_overflow(token_factory):
+    _, erc20, account = token_factory
+    # fetching the previously minted totalSupply and verifying the overflow check
+    # (totalSupply >= 2**256) should fail, (totalSupply < 2**256) should pass
+    execution_info = await erc20.totalSupply().invoke()
+    previous_supply = execution_info.result.totalSupply
+
+    # pass_amount subtracts the already minted supply from MAX_UINT256 in order for
+    # the minted supply to equal MAX_UINT256
+    # (2**128 - 1, 2**128 - 1)
+    pass_amount = (
+        MAX_UINT256[0] - previous_supply[0],  # 2**128 - 1
+        MAX_UINT256[1] - previous_supply[1]   # 2**128 - 1
+    )
+
+    await signer.send_transaction(account, erc20.contract_address, 'mint', [RECIPIENT, *pass_amount])
+
+    # fail_amount displays the edge case where any addition over MAX_SUPPLY
+    # should result in a failing tx
+    fail_amount = (
+        pass_amount[0] + 1,  # 2**128 (will overflow)
+        pass_amount[1]       # 2**128 - 1
+    )
+
+    await assert_revert(signer.send_transaction(
+        account,
+        erc20.contract_address,
+        'mint',
+        [RECIPIENT, *fail_amount]),
+        reverted_with="ERC20: mint overflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mint_invalid_uint256(token_factory):
+    _, erc20, account = token_factory
+
+    await assert_revert(signer.send_transaction(
+        account,
+        erc20.contract_address,
+        'mint',
+        [RECIPIENT, *INVALID_UINT256]),
+        reverted_with="ERC20: amount is not a valid Uint256"
+    )

--- a/openzeppelin/tests/token/erc20/test_ERC20_Pausable.py
+++ b/openzeppelin/tests/token/erc20/test_ERC20_Pausable.py
@@ -1,0 +1,171 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import Signer, uint, str_to_felt, assert_revert, contract_path
+
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+async def token_factory():
+    starknet = await Starknet.empty()
+    owner = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+
+    other = await starknet.deploy(
+        contract_path("openzeppelin/account/Account.cairo"),
+        constructor_calldata=[signer.public_key]
+    )
+
+    token = await starknet.deploy(
+        contract_path("openzeppelin/token/erc20/ERC20_Pausable.cairo"),
+        constructor_calldata=[
+            str_to_felt("Pausable Token"),
+            str_to_felt("PTKN"),
+            18,
+            *uint(1000),
+            owner.contract_address,
+            owner.contract_address
+        ]
+    )
+    return starknet, token, owner, other
+
+
+@pytest.mark.asyncio
+async def test_constructor(token_factory):
+    _, token, owner, _ = token_factory
+
+    execution_info = await token.name().call()
+    assert execution_info.result == (str_to_felt("Pausable Token"),)
+
+    execution_info = await token.symbol().call()
+    assert execution_info.result == (str_to_felt("PTKN"),)
+
+    execution_info = await token.decimals().call()
+    assert execution_info.result.decimals == 18
+
+    execution_info = await token.balanceOf(owner.contract_address).call()
+    assert execution_info.result.balance == uint(1000)
+
+    execution_info = await token.paused().call()
+    assert execution_info.result.paused == 0
+
+
+@pytest.mark.asyncio
+async def test_pause(token_factory):
+    _, token, owner, other = token_factory
+    amount = uint(200)
+
+    await signer.send_transaction(owner, token.contract_address, 'pause', [])
+
+    execution_info = await token.paused().call()
+    assert execution_info.result.paused == 1
+
+    await assert_revert(signer.send_transaction(
+        owner,
+        token.contract_address,
+        'transfer',
+        [other.contract_address, *amount]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    await assert_revert(signer.send_transaction(
+        owner,
+        token.contract_address,
+        'transferFrom',
+        [other.contract_address, other.contract_address, *amount]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    await assert_revert(signer.send_transaction(
+        owner,
+        token.contract_address,
+        'approve',
+        [other.contract_address, *amount]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    await assert_revert(signer.send_transaction(
+        owner,
+        token.contract_address,
+        'increaseAllowance',
+        [other.contract_address, *amount]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    await assert_revert(signer.send_transaction(
+        owner,
+        token.contract_address,
+        'decreaseAllowance',
+        [other.contract_address, *amount]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unpause(token_factory):
+    _, token, owner, other = token_factory
+    amount = uint(200)
+
+    await signer.send_transaction(owner, token.contract_address, 'unpause', [])
+    execution_info = await token.paused().call()
+    assert execution_info.result.paused == 0
+
+    success = await signer.send_transaction(
+        owner,
+        token.contract_address,
+        'transfer',
+        [other.contract_address, *amount]
+    )
+    assert success.result.response == [1]  # [1] means true
+
+    success = await signer.send_transaction(
+        owner,
+        token.contract_address,
+        'approve',
+        [other.contract_address, *amount]
+    )
+    assert success.result.response == [1]  # [1] means true
+
+    success = await signer.send_transaction(
+        other,
+        token.contract_address,
+        'transferFrom',
+        [owner.contract_address, other.contract_address, *amount]
+    )
+    assert success.result.response == [1]  # [1] means true
+
+    success = await signer.send_transaction(
+        owner,
+        token.contract_address,
+        'increaseAllowance',
+        [other.contract_address, *amount]
+    )
+    assert success.result.response == [1]  # [1] means true
+
+    success = await signer.send_transaction(
+        owner,
+        token.contract_address,
+        'decreaseAllowance',
+        [other.contract_address, *amount]
+    )
+    assert success.result.response == [1]  # [1] means true
+
+
+@pytest.mark.asyncio
+async def test_only_owner(token_factory):
+    _, token, _, other = token_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            other, token.contract_address, 'pause', []),
+        reverted_with="Ownable: caller is not the owner"
+    )
+
+    assert assert_revert(
+        signer.send_transaction(
+            other, token.contract_address, 'unpause', []),
+        reverted_with="Ownable: caller is not the owner"
+    )

--- a/openzeppelin/tests/token/erc20/test_ERC20_Upgradeable.py
+++ b/openzeppelin/tests/token/erc20/test_ERC20_Upgradeable.py
@@ -1,0 +1,194 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, to_uint, sub_uint, str_to_felt, assert_revert,
+    get_contract_def, cached_contract
+)
+
+
+signer = Signer(123456789987654321)
+
+USER = 999
+INIT_SUPPLY = to_uint(1000)
+AMOUNT = to_uint(250)
+NAME = str_to_felt('Upgradeable Token')
+SYMBOL = str_to_felt('UTKN')
+DECIMALS = 18
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = get_contract_def('openzeppelin/account/Account.cairo')
+    token_def = get_contract_def(
+        'openzeppelin/token/erc20/ERC20_Upgradeable.cairo')
+    proxy_def = get_contract_def('openzeppelin/upgrades/Proxy.cairo')
+
+    return account_def, token_def, proxy_def
+
+
+@pytest.fixture(scope='module')
+async def token_init(contract_defs):
+    account_def, token_def, proxy_def = contract_defs
+    starknet = await Starknet.empty()
+    account1 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    account2 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    token_v1 = await starknet.deploy(
+        contract_def=token_def,
+        constructor_calldata=[]
+    )
+    token_v2 = await starknet.deploy(
+        contract_def=token_def,
+        constructor_calldata=[]
+    )
+    proxy = await starknet.deploy(
+        contract_def=proxy_def,
+        constructor_calldata=[token_v1.contract_address]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        token_v1,
+        token_v2,
+        proxy
+    )
+
+
+@pytest.fixture
+def token_factory(contract_defs, token_init):
+    account_def, token_def, proxy_def = contract_defs
+    state, account1, account2, token_v1, token_v2, proxy = token_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_def, account1)
+    account2 = cached_contract(_state, account_def, account2)
+    token_v1 = cached_contract(_state, token_def, token_v1)
+    token_v2 = cached_contract(_state, token_def, token_v2)
+    proxy = cached_contract(_state, proxy_def, proxy)
+
+    return account1, account2, token_v1, token_v2, proxy
+
+
+@pytest.fixture
+async def after_initializer(token_factory):
+    admin, other, token_v1, token_v2, proxy = token_factory
+
+    # initialize
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            NAME,
+            SYMBOL,
+            DECIMALS,
+            *INIT_SUPPLY,
+            admin.contract_address,
+            admin.contract_address
+        ]
+    )
+
+    return admin, other, token_v1, token_v2, proxy
+
+
+@pytest.mark.asyncio
+async def test_constructor(token_factory):
+    admin, _, _, _, proxy = token_factory
+
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            NAME,
+            SYMBOL,
+            DECIMALS,
+            *INIT_SUPPLY,
+            admin.contract_address,
+            admin.contract_address
+        ])
+
+    # check name
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'name', [])
+    assert execution_info.result.response == [NAME]
+
+    # check symbol
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'symbol', []
+    )
+    assert execution_info.result.response == [SYMBOL]
+
+    # check decimals
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'decimals', []
+    )
+    assert execution_info.result.response == [DECIMALS]
+
+    # check total supply
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'totalSupply', []
+    )
+    assert execution_info.result.response == [*INIT_SUPPLY]
+
+
+@pytest.mark.asyncio
+async def test_upgrade(after_initializer):
+    admin, _, _, token_v2, proxy = after_initializer
+
+    # transfer
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'transfer', [
+            USER,
+            *AMOUNT
+        ]
+    )
+
+    # upgrade
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            token_v2.contract_address
+        ]
+    )
+
+    # check admin balance
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'balanceOf', [
+            admin.contract_address
+        ]
+    )
+    assert execution_info.result.response == [*sub_uint(INIT_SUPPLY, AMOUNT)]
+
+    # check USER balance
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'balanceOf', [
+            USER
+        ]
+    )
+    assert execution_info.result.response == [*AMOUNT]
+
+    # check total supply
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'totalSupply', []
+    )
+    assert execution_info.result.response == [*INIT_SUPPLY]
+
+
+@pytest.mark.asyncio
+async def test_upgrade_from_nonadmin(after_initializer):
+    admin, non_admin, _, token_v2, proxy = after_initializer
+
+    # should revert
+    await assert_revert(
+        signer.send_transaction(
+            non_admin, proxy.contract_address, 'upgrade', [
+                token_v2.contract_address
+            ]
+        )
+    )
+
+    # should upgrade from admin
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            token_v2.contract_address
+        ]
+    )

--- a/openzeppelin/tests/token/erc721/test_ERC721_Mintable_Burnable.py
+++ b/openzeppelin/tests/token/erc721/test_ERC721_Mintable_Burnable.py
@@ -1,0 +1,1208 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, str_to_felt, ZERO_ADDRESS, TRUE, FALSE, assert_revert, INVALID_UINT256,
+    assert_event_emitted, get_contract_def, cached_contract, to_uint, sub_uint, add_uint
+)
+
+
+signer = Signer(123456789987654321)
+
+NONEXISTENT_TOKEN = to_uint(999)
+# random token IDs
+TOKENS = [to_uint(5042), to_uint(793)]
+# test token
+TOKEN = TOKENS[0]
+# random user address
+RECIPIENT = 555
+# random data (mimicking bytes in Solidity)
+DATA = [0x42, 0x89, 0x55]
+# random URIs
+SAMPLE_URI_1 = str_to_felt('mock://mytoken.v1')
+SAMPLE_URI_2 = str_to_felt('mock://mytoken.v2')
+
+# selector ids
+IERC165_ID = 0x01ffc9a7
+IERC721_ID = 0x80ac58cd
+IERC721_METADATA_ID = 0x5b5e139f
+INVALID_ID = 0xffffffff
+UNSUPPORTED_ID = 0xabcd1234
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = get_contract_def('openzeppelin/account/Account.cairo')
+    erc721_def = get_contract_def(
+        'openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo')
+    erc721_holder_def = get_contract_def(
+        'openzeppelin/token/erc721/utils/ERC721_Holder.cairo')
+    unsupported_def = get_contract_def(
+        'openzeppelin/security/initializable.cairo')
+
+    return account_def, erc721_def, erc721_holder_def, unsupported_def
+
+
+@pytest.fixture(scope='module')
+async def erc721_init(contract_defs):
+    account_def, erc721_def, erc721_holder_def, unsupported_def = contract_defs
+    starknet = await Starknet.empty()
+    account1 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    account2 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    erc721 = await starknet.deploy(
+        contract_def=erc721_def,
+        constructor_calldata=[
+            str_to_felt("Non Fungible Token"),  # name
+            str_to_felt("NFT"),                 # ticker
+            account1.contract_address           # owner
+        ]
+    )
+    erc721_holder = await starknet.deploy(
+        contract_def=erc721_holder_def,
+        constructor_calldata=[]
+    )
+    unsupported = await starknet.deploy(
+        contract_def=unsupported_def,
+        constructor_calldata=[]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc721,
+        erc721_holder,
+        unsupported
+    )
+
+
+@pytest.fixture
+def erc721_factory(contract_defs, erc721_init):
+    account_def, erc721_def, erc721_holder_def, unsupported_def = contract_defs
+    state, account1, account2, erc721, erc721_holder, unsupported = erc721_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_def, account1)
+    account2 = cached_contract(_state, account_def, account2)
+    erc721 = cached_contract(_state, erc721_def, erc721)
+    erc721_holder = cached_contract(_state, erc721_holder_def, erc721_holder)
+    unsupported = cached_contract(_state, unsupported_def, unsupported)
+
+    return erc721, account1, account2, erc721_holder, unsupported
+
+
+# Note that depending on what's being tested, test cases alternate between
+# accepting `erc721_minted`, `erc721_factory`, and `erc721_unsupported` fixtures
+@pytest.fixture
+async def erc721_minted(erc721_factory):
+    erc721, account, account2, erc721_holder, _ = erc721_factory
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    return erc721, account, account2, erc721_holder
+
+
+# Fixture for testing contracts that do not accept safe ERC721 transfers
+@pytest.fixture
+async def erc721_unsupported(erc721_factory):
+    erc721, account, account2, erc721_holder, unsupported = erc721_factory
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    return erc721, account, account2, erc721_holder, unsupported
+
+
+#
+# Constructor
+#
+
+
+@pytest.mark.asyncio
+async def test_constructor(erc721_factory):
+    erc721, _, _, _, _ = erc721_factory
+    execution_info = await erc721.name().invoke()
+    assert execution_info.result == (str_to_felt("Non Fungible Token"),)
+
+    execution_info = await erc721.symbol().invoke()
+    assert execution_info.result == (str_to_felt("NFT"),)
+
+
+#
+# balanceOf
+#
+
+
+@pytest.mark.asyncio
+async def test_balanceOf(erc721_factory):
+    erc721, account, _, _, _ = erc721_factory
+
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    execution_info = await erc721.balanceOf(account.contract_address).invoke()
+    n_tokens = len(TOKENS)
+    assert execution_info.result == (to_uint(n_tokens),)
+
+    # user should have zero tokens
+    execution_info = await erc721.balanceOf(RECIPIENT).invoke()
+    assert execution_info.result == (to_uint(0),)
+
+
+@pytest.mark.asyncio
+async def test_balanceOf_zero_address(erc721_factory):
+    erc721, account, _, _, _ = erc721_factory
+
+    # mint tokens to account
+    await signer.send_transaction(
+        account, erc721.contract_address, 'mint', [
+            account.contract_address, *TOKEN]
+    )
+
+    # should revert when querying zero address
+    await assert_revert(
+        erc721.balanceOf(ZERO_ADDRESS).invoke(),
+        reverted_with="ERC721: balance query for the zero address"
+    )
+
+
+#
+# ownerOf
+#
+
+
+@pytest.mark.asyncio
+async def test_ownerOf(erc721_factory):
+    erc721, account, _, _, _ = erc721_factory
+
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+        # should return account's address
+        execution_info = await erc721.ownerOf(token).invoke()
+        assert execution_info.result == (account.contract_address,)
+
+
+@pytest.mark.asyncio
+async def test_ownerOf_nonexistent_token(erc721_factory):
+    erc721, account, _, _, _ = erc721_factory
+
+    # mint token to account
+    await signer.send_transaction(
+        account, erc721.contract_address, 'mint', [
+            account.contract_address, *TOKEN]
+    )
+
+    # should revert when querying nonexistent token
+    await assert_revert(
+        erc721.ownerOf(NONEXISTENT_TOKEN).invoke(),
+        reverted_with="ERC721: owner query for nonexistent token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ownerOf_invalid_uint256(erc721_factory):
+    erc721, _, _, _, _ = erc721_factory
+
+    # should revert when querying nonexistent token
+    await assert_revert(
+        erc721.ownerOf(INVALID_UINT256).invoke(),
+        reverted_with="ERC721: token_id is not a valid Uint256"
+    )
+
+
+#
+# mint
+#
+
+
+@pytest.mark.asyncio
+async def test_mint_emits_event(erc721_factory):
+    erc721, account, _, _, _ = erc721_factory
+
+    # mint token to account
+    tx_exec_info = await signer.send_transaction(
+        account, erc721.contract_address, 'mint', [
+            account.contract_address, *TOKEN]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='Transfer',
+        data=[
+            ZERO_ADDRESS,
+            account.contract_address,
+            *TOKEN
+        ]
+    )
+
+
+# using fixture with already minted tokens
+@pytest.mark.asyncio
+async def test_mint(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    # checks balance
+    execution_info = await erc721.balanceOf(account.contract_address).invoke()
+    assert execution_info.result == (to_uint(2),)
+
+    # checks that account owns correct tokens
+    for token in TOKENS:
+        execution_info = await erc721.ownerOf(token).invoke()
+        assert execution_info.result == (account.contract_address,)
+
+
+@pytest.mark.asyncio
+async def test_mint_duplicate_token_id(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    # minting duplicate token_id should fail
+    await assert_revert(signer.send_transaction(
+        account, erc721.contract_address, 'mint', [
+            account.contract_address,
+            *TOKEN
+        ]),
+        reverted_with="ERC721: token already minted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mint_to_zero_address(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    # minting to zero address should fail
+    await assert_revert(signer.send_transaction(
+        account, erc721.contract_address, 'mint', [
+            ZERO_ADDRESS,
+            *NONEXISTENT_TOKEN
+        ]),
+        reverted_with="ERC721: cannot mint to the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mint_approve_should_be_zero_address(erc721_minted):
+    erc721, _, _, _ = erc721_minted
+
+    # approved address should be zero for newly minted tokens
+    for token in TOKENS:
+        execution_info = await erc721.getApproved(token).invoke()
+        assert execution_info.result == (0,)
+
+
+@pytest.mark.asyncio
+async def test_mint_by_not_owner(erc721_factory):
+    erc721, _, not_owner, _, _ = erc721_factory
+
+    # minting from not_owner should fail
+    await assert_revert(signer.send_transaction(
+        not_owner, erc721.contract_address, 'mint', [
+            not_owner.contract_address,
+            *TOKENS[0]
+        ]),
+        reverted_with="Ownable: caller is not the owner"
+    )
+
+
+#
+# burn
+#
+
+
+@pytest.mark.asyncio
+async def test_burn(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    execution_info = await erc721.balanceOf(account.contract_address).invoke()
+    previous_balance = execution_info.result.balance
+
+    # burn token
+    await signer.send_transaction(
+        account, erc721.contract_address, 'burn', [*TOKEN]
+    )
+
+    # account balance should subtract one
+    execution_info = await erc721.balanceOf(account.contract_address).invoke()
+    assert execution_info.result.balance == sub_uint(
+        previous_balance, to_uint(1)
+    )
+
+    # approve should be cleared to zero, therefore,
+    # 'getApproved()' call should fail
+    await assert_revert(
+        erc721.getApproved(TOKEN).invoke(),
+        reverted_with="ERC721: approved query for nonexistent token"
+    )
+
+    # 'token_to_burn' owner should be zero; therefore,
+    # 'ownerOf()' call should fail
+    await assert_revert(
+        erc721.ownerOf(TOKEN).invoke(),
+        reverted_with="ERC721: owner query for nonexistent token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_emits_event(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    # mint token to account
+    tx_exec_info = await signer.send_transaction(
+        account, erc721.contract_address, 'burn', [
+            *TOKEN
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            ZERO_ADDRESS,
+            *TOKEN
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_nonexistent_token(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    await assert_revert(signer.send_transaction(
+        account, erc721.contract_address, 'burn', [
+            *NONEXISTENT_TOKEN
+        ]),
+        reverted_with="ERC721: owner query for nonexistent token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_unowned_token(erc721_minted):
+    erc721, account, other, _ = erc721_minted
+
+    # other should not be able to burn account's token
+    await assert_revert(
+        signer.send_transaction(
+            other, erc721.contract_address, 'burn', [*TOKEN]
+        ),
+        reverted_with="ERC721: caller is not the token owner"
+    )
+
+    # account can burn their own token
+    await signer.send_transaction(
+        account, erc721.contract_address, 'burn', [*TOKEN]
+    )
+
+
+@pytest.mark.asyncio
+async def test_burn_from_zero_address(erc721_minted):
+    erc721, _, _, _ = erc721_minted
+
+    await assert_revert(
+        erc721.burn(TOKEN).invoke(),
+        reverted_with="ERC721: caller is not the token owner"
+    )
+
+
+#
+# approve
+#
+
+
+@pytest.mark.asyncio
+async def test_approve(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'approve', [
+            spender.contract_address, *TOKEN]
+    )
+
+    execution_info = await erc721.getApproved(TOKEN).invoke()
+    assert execution_info.result == (spender.contract_address,)
+
+
+@pytest.mark.asyncio
+async def test_approve_emits_event(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    # mint token to account
+    tx_exec_info = await signer.send_transaction(
+        account, erc721.contract_address, 'approve', [
+            spender.contract_address,
+            *TOKEN
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            spender.contract_address,
+            *TOKEN
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_on_setApprovalForAll(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    # set approval_for_all from account to spender
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, TRUE]
+    )
+
+    # approve spender to spend account's token to recipient
+    await signer.send_transaction(
+        spender, erc721.contract_address, 'approve', [
+            RECIPIENT, *TOKEN]
+    )
+
+    execution_info = await erc721.getApproved(TOKEN).invoke()
+    assert execution_info.result == (RECIPIENT,)
+
+
+@pytest.mark.asyncio
+async def test_approve_from_zero_address(erc721_minted):
+    erc721, _, spender, _ = erc721_minted
+
+    # Without using an account abstraction, the caller address
+    # (get_caller_address) is zero
+    await assert_revert(
+        erc721.approve(
+            spender.contract_address, TOKEN).invoke(),
+        reverted_with="ERC721: cannot approve from the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_owner_is_recipient(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    # should fail when owner is the same as address-to-be-approved
+    await assert_revert(
+        signer.send_transaction(
+            account, erc721.contract_address, 'approve', [
+                account.contract_address,
+                *TOKEN
+            ]),
+        reverted_with="ERC721: approval to current owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_not_owner_or_operator(erc721_factory):
+    erc721, account, spender, _, _ = erc721_factory
+
+    # mint to recipient — NOT account
+    await signer.send_transaction(
+        account, erc721.contract_address, 'mint', [
+            RECIPIENT, *TOKEN]
+    )
+
+    # 'approve' should fail since recipient owns token
+    await assert_revert(signer.send_transaction(
+        account, erc721.contract_address, 'approve', [
+            spender.contract_address,
+            *TOKEN
+        ]),
+        reverted_with="ERC721: approve caller is not owner nor approved for all"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_on_already_approved(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    # first approval
+    await signer.send_transaction(
+        account, erc721.contract_address, 'approve', [
+            spender.contract_address, *TOKEN]
+    )
+
+    # repeat approval
+    await signer.send_transaction(
+        account, erc721.contract_address, 'approve', [
+            spender.contract_address, *TOKEN]
+    )
+
+    # check that approval does not change
+    execution_info = await erc721.getApproved(TOKEN).invoke()
+    assert execution_info.result == (spender.contract_address,)
+
+
+@pytest.mark.asyncio
+async def test_getApproved_nonexistent_token(erc721_minted):
+    erc721, _, _, _ = erc721_minted
+
+    await assert_revert(
+        erc721.getApproved(NONEXISTENT_TOKEN).invoke(),
+        reverted_with="ERC721: approved query for nonexistent token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_getApproved_invalid_uint256(erc721_minted):
+    erc721, _, _, _ = erc721_minted
+
+    await assert_revert(
+        erc721.getApproved(INVALID_UINT256).invoke(),
+        reverted_with="ERC721: token_id is not a valid Uint256"
+    )
+
+
+#
+# setApprovalForAll
+#
+
+
+@pytest.mark.asyncio
+async def test_setApprovalForAll(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, TRUE]
+    )
+
+    execution_info = await erc721.isApprovedForAll(
+        account.contract_address, spender.contract_address).invoke()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_setApprovalForAll_emits_event(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    tx_exec_info = await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, TRUE]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='ApprovalForAll',
+        data=[
+            account.contract_address,
+            spender.contract_address,
+            TRUE
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_setApprovalForAll_when_operator_was_set_as_not_approved(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, FALSE]
+    )
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, TRUE]
+    )
+
+    execution_info = await erc721.isApprovedForAll(
+        account.contract_address, spender.contract_address).invoke()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_setApprovalForAll_with_invalid_bool_arg(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    not_bool = 2
+
+    await assert_revert(
+        signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address,
+                not_bool
+            ]),
+        reverted_with="ERC721: approved is not a Cairo boolean")
+
+
+@pytest.mark.asyncio
+async def test_setApprovalForAll_owner_is_operator(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    await assert_revert(
+        signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                account.contract_address,
+                TRUE
+            ]),
+        reverted_with="ERC721: approve to caller"
+    )
+
+
+@pytest.mark.asyncio
+async def test_setApprovalForAll_from_zero_address(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    await assert_revert(
+        erc721.setApprovalForAll(account.contract_address, TRUE).invoke(),
+        reverted_with="ERC721: either the caller or operator is the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_setApprovalForAll_operator_is_zero_address(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    await assert_revert(
+        signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                ZERO_ADDRESS,
+                TRUE
+            ]),
+        reverted_with="ERC721: either the caller or operator is the zero address"
+    )
+
+
+#
+# transferFrom
+#
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_owner(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    # get account's previous balance
+    execution_info = await erc721.balanceOf(account.contract_address).invoke()
+    previous_balance = execution_info.result.balance
+
+    # transfers token from account to recipient
+    await signer.send_transaction(
+        account, erc721.contract_address, 'transferFrom', [
+            account.contract_address, RECIPIENT, *TOKEN]
+    )
+
+    # checks recipient balance
+    execution_info = await erc721.balanceOf(RECIPIENT).invoke()
+    assert execution_info.result == (to_uint(1),)
+
+    # checks account balance
+    execution_info = await erc721.balanceOf(account.contract_address).invoke()
+    assert execution_info.result.balance == sub_uint(
+        previous_balance, to_uint(1))
+
+    # checks token has new owner
+    execution_info = await erc721.ownerOf(TOKEN).invoke()
+    assert execution_info.result == (RECIPIENT,)
+
+    # checks approval is cleared for token_id
+    execution_info = await erc721.getApproved(TOKEN).invoke()
+    assert execution_info.result == (0,)
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_emits_events(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    # setApprovalForAll
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, TRUE]
+    )
+
+    # spender transfers token from account to recipient
+    tx_exec_info = await signer.send_transaction(
+        spender, erc721.contract_address, 'transferFrom', [
+            account.contract_address,
+            RECIPIENT,
+            *TOKEN
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            RECIPIENT,
+            *TOKEN
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            ZERO_ADDRESS,
+            *TOKEN
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_approved_user(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    # approve spender
+    await signer.send_transaction(
+        account, erc721.contract_address, 'approve', [
+            spender.contract_address, *TOKEN]
+    )
+
+    # spender transfers token from account to recipient
+    await signer.send_transaction(
+        spender, erc721.contract_address, 'transferFrom', [
+            account.contract_address, RECIPIENT, *TOKEN]
+    )
+
+    # checks user balance
+    execution_info = await erc721.balanceOf(RECIPIENT).invoke()
+    assert execution_info.result == (to_uint(1),)
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_operator(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    # setApprovalForAll
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, TRUE]
+    )
+
+    # spender transfers token from account to recipient
+    await signer.send_transaction(
+        spender, erc721.contract_address, 'transferFrom', [
+            account.contract_address, RECIPIENT, *TOKEN]
+    )
+
+    # checks user balance
+    execution_info = await erc721.balanceOf(RECIPIENT).invoke()
+    assert execution_info.result == (to_uint(1),)
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_when_not_approved_or_owner(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    # setApprovalForAll to false
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, FALSE]
+    )
+
+    # should be rejected when not approved
+    await assert_revert(signer.send_transaction(
+        spender, erc721.contract_address, 'transferFrom', [
+            account.contract_address,
+            RECIPIENT,
+            *TOKEN
+        ]),
+        reverted_with="ERC721: either is not approved or the caller is the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_to_zero_address(erc721_minted):
+    erc721, account, spender, _ = erc721_minted
+
+    # setApprovalForAll
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, TRUE]
+    )
+
+    # to zero address should be rejected
+    await assert_revert(signer.send_transaction(
+        spender, erc721.contract_address, 'transferFrom', [
+            account.contract_address,
+            ZERO_ADDRESS,
+            *TOKEN
+        ]),
+        reverted_with="ERC721: cannot transfer to the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_invalid_uint256(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    await assert_revert(
+        signer.send_transaction(
+            account, erc721.contract_address, 'transferFrom', [
+                account.contract_address,
+                RECIPIENT,
+                *INVALID_UINT256
+            ]),
+        reverted_with="ERC721: token_id is not a valid Uint256"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transferFrom_from_zero_address(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    # caller address is `0` when not using an account contract
+    await assert_revert(
+        erc721.transferFrom(
+            account.contract_address,
+            RECIPIENT,
+            TOKEN
+        ).invoke(),
+        reverted_with="ERC721: either is not approved or the caller is the zero address"
+    )
+
+
+#
+# supportsInterface
+#
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('interface_id, result', [
+    [IERC165_ID, TRUE],
+    [IERC721_ID, TRUE],
+    [IERC721_METADATA_ID, TRUE],
+    [INVALID_ID, FALSE],
+    [UNSUPPORTED_ID, FALSE],
+])
+async def test_supportsInterface(erc721_factory, interface_id, result):
+    erc721, _, _, _, _ = erc721_factory
+
+    execution_info = await erc721.supportsInterface(interface_id).invoke()
+    assert execution_info.result == (result,)
+
+
+#
+# safeTransferFrom
+#
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom(erc721_minted):
+    erc721, account, _, erc721_holder = erc721_minted
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'safeTransferFrom', [
+            account.contract_address,
+            erc721_holder.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    # check balance
+    execution_info = await erc721.balanceOf(erc721_holder.contract_address).invoke()
+    assert execution_info.result == (to_uint(1),)
+
+    # check owner
+    execution_info = await erc721.ownerOf(TOKEN).invoke()
+    assert execution_info.result == (erc721_holder.contract_address,)
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_emits_events(erc721_minted):
+    erc721, account, _, erc721_holder = erc721_minted
+
+    tx_exec_info = await signer.send_transaction(
+        account, erc721.contract_address, 'safeTransferFrom', [
+            account.contract_address,
+            erc721_holder.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='Transfer',
+        data=[
+            account.contract_address,
+            erc721_holder.contract_address,
+            *TOKEN
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='Approval',
+        data=[
+            account.contract_address,
+            ZERO_ADDRESS,
+            *TOKEN
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_from_approved(erc721_minted):
+    erc721, account, spender, erc721_holder = erc721_minted
+
+    execution_info = await erc721.balanceOf(erc721_holder.contract_address).invoke()
+    previous_balance = execution_info.result.balance
+
+    # approve spender
+    await signer.send_transaction(
+        account, erc721.contract_address, 'approve', [
+            spender.contract_address, *TOKEN]
+    )
+
+    # spender transfers token from account to erc721_holder
+    await signer.send_transaction(
+        spender, erc721.contract_address, 'safeTransferFrom', [
+            account.contract_address,
+            erc721_holder.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    # erc721_holder balance check
+    execution_info = await erc721.balanceOf(erc721_holder.contract_address).invoke()
+    assert execution_info.result.balance == add_uint(
+        previous_balance, to_uint(1)
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_from_operator(erc721_minted):
+    erc721, account, spender, erc721_holder = erc721_minted
+
+    execution_info = await erc721.balanceOf(erc721_holder.contract_address).invoke()
+    previous_balance = execution_info.result.balance
+
+    # setApprovalForAll
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setApprovalForAll', [
+            spender.contract_address, TRUE]
+    )
+
+    # spender transfers token from account to erc721_holder
+    await signer.send_transaction(
+        spender, erc721.contract_address, 'safeTransferFrom', [
+            account.contract_address,
+            erc721_holder.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    # erc721_holder balance check
+    execution_info = await erc721.balanceOf(erc721_holder.contract_address).invoke()
+    assert execution_info.result.balance == add_uint(
+        previous_balance, to_uint(1)
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_when_not_approved_or_owner(erc721_minted):
+    erc721, account, spender, erc721_holder = erc721_minted
+
+    # should fail when not approved or owner
+    await assert_revert(signer.send_transaction(
+        spender, erc721.contract_address, 'safeTransferFrom', [
+            account.contract_address,
+            erc721_holder.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]),
+        reverted_with="ERC721: either is not approved or the caller is the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_to_zero_address(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    # to zero address should be rejected
+    await assert_revert(signer.send_transaction(
+        account, erc721.contract_address, 'safeTransferFrom', [
+            account.contract_address,
+            ZERO_ADDRESS,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]),
+        reverted_with="ERC721: cannot transfer to the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_from_zero_address(erc721_minted):
+    erc721, account, _, erc721_holder = erc721_minted
+
+    # caller address is `0` when not using an account contract
+    await assert_revert(
+        erc721.safeTransferFrom(
+            account.contract_address,
+            erc721_holder.contract_address,
+            TOKEN,
+            DATA
+        ).invoke(),
+        reverted_with="ERC721: either is not approved or the caller is the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_to_unsupported_contract(erc721_unsupported):
+    erc721, account, _, _, unsupported = erc721_unsupported
+
+    await assert_revert(
+        signer.send_transaction(
+            account, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                unsupported.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA,
+            ])
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_to_account(erc721_minted):
+    erc721, account, account2, _ = erc721_minted
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'safeTransferFrom', [
+            account.contract_address,
+            account2.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    # check balance
+    execution_info = await erc721.balanceOf(account2.contract_address).invoke()
+    assert execution_info.result == (to_uint(1),)
+
+    # check owner
+    execution_info = await erc721.ownerOf(TOKEN).invoke()
+    assert execution_info.result == (account2.contract_address,)
+
+
+@pytest.mark.asyncio
+async def test_safeTransferFrom_invalid_uint256(erc721_minted):
+    erc721, account, _, erc721_holder = erc721_minted
+
+    await assert_revert(
+        signer.send_transaction(
+            account, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                erc721_holder.contract_address,
+                *INVALID_UINT256,
+                len(DATA),
+                *DATA
+            ]),
+        reverted_with="ERC721: token_id is not a valid Uint256"
+    )
+
+
+#
+# tokenURI
+#
+
+
+@pytest.mark.asyncio
+async def test_tokenURI(erc721_minted):
+    erc721, account, _, _ = erc721_minted
+
+    token_1 = TOKENS[0]
+    token_2 = TOKENS[1]
+
+    # should be zero when tokenURI is not set
+    execution_info = await erc721.tokenURI(token_1).invoke()
+    assert execution_info.result == (0,)
+
+    # setTokenURI for token_1
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setTokenURI', [
+            *token_1,
+            SAMPLE_URI_1
+        ]
+    )
+
+    execution_info = await erc721.tokenURI(token_1).invoke()
+    assert execution_info.result == (SAMPLE_URI_1,)
+
+    # setTokenURI for token_2
+    await signer.send_transaction(
+        account, erc721.contract_address, 'setTokenURI', [
+            *token_2,
+            SAMPLE_URI_2
+        ]
+    )
+
+    execution_info = await erc721.tokenURI(token_2).invoke()
+    assert execution_info.result == (SAMPLE_URI_2,)
+
+
+@pytest.mark.asyncio
+async def test_tokenURI_should_revert_for_nonexistent_token(erc721_minted):
+    erc721, _, _, _ = erc721_minted
+
+    # should revert for nonexistent token
+    await assert_revert(
+        erc721.tokenURI(NONEXISTENT_TOKEN).invoke(),
+        reverted_with="ERC721_Metadata: URI query for nonexistent token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_setTokenURI_from_not_owner(erc721_minted):
+    erc721, _, not_owner, _ = erc721_minted
+
+    await assert_revert(signer.send_transaction(
+        not_owner, erc721.contract_address, 'setTokenURI', [
+            *TOKEN,
+            SAMPLE_URI_1
+        ]),
+        reverted_with="Ownable: caller is not the owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_setTokenURI_for_nonexistent_token(erc721_minted):
+    erc721, _, not_owner, _ = erc721_minted
+
+    await assert_revert(signer.send_transaction(
+        not_owner, erc721.contract_address, 'setTokenURI', [
+            *NONEXISTENT_TOKEN,
+            SAMPLE_URI_1
+        ]),
+        reverted_with="Ownable: caller is not the owner"
+    )

--- a/openzeppelin/tests/token/erc721/test_ERC721_Mintable_Pausable.py
+++ b/openzeppelin/tests/token/erc721/test_ERC721_Mintable_Pausable.py
@@ -1,0 +1,217 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, str_to_felt, TRUE, FALSE, get_contract_def, cached_contract, assert_revert, to_uint
+)
+
+
+signer = Signer(123456789987654321)
+
+# random token IDs
+TOKENS = [to_uint(5042), to_uint(793)]
+TOKEN_TO_MINT = to_uint(33)
+# random data (mimicking bytes in Solidity)
+DATA = [0x42, 0x89, 0x55]
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = get_contract_def('openzeppelin/account/Account.cairo')
+    erc721_def = get_contract_def(
+        'openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo')
+    erc721_holder_def = get_contract_def(
+        'openzeppelin/token/erc721/utils/ERC721_Holder.cairo')
+
+    return account_def, erc721_def, erc721_holder_def
+
+
+@pytest.fixture(scope='module')
+async def erc721_init(contract_defs):
+    account_def, erc721_def, erc721_holder_def = contract_defs
+    starknet = await Starknet.empty()
+    account1 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    account2 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    erc721 = await starknet.deploy(
+        contract_def=erc721_def,
+        constructor_calldata=[
+            str_to_felt("Non Fungible Token"),  # name
+            str_to_felt("NFT"),                 # ticker
+            account1.contract_address
+        ]
+    )
+    erc721_holder = await starknet.deploy(
+        contract_def=erc721_holder_def,
+        constructor_calldata=[]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc721,
+        erc721_holder
+    )
+
+
+@pytest.fixture
+def erc721_factory(contract_defs, erc721_init):
+    account_def, erc721_def, erc721_holder_def = contract_defs
+    state, account1, account2, erc721, erc721_holder = erc721_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_def, account1)
+    account2 = cached_contract(_state, account_def, account2)
+    erc721 = cached_contract(_state, erc721_def, erc721)
+    erc721_holder = cached_contract(_state, erc721_holder_def, erc721_holder)
+
+    return erc721, account1, account2, erc721_holder
+
+
+@pytest.fixture
+async def erc721_minted(erc721_factory):
+    erc721, account, account2, erc721_holder = erc721_factory
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    return erc721, account, account2, erc721_holder
+
+
+@pytest.mark.asyncio
+async def test_pause(erc721_minted):
+    erc721, owner, other, erc721_holder = erc721_minted
+
+    # pause
+    await signer.send_transaction(owner, erc721.contract_address, 'pause', [])
+
+    execution_info = await erc721.paused().invoke()
+    assert execution_info.result.paused == TRUE
+
+    await assert_revert(signer.send_transaction(
+        owner, erc721.contract_address, 'approve', [
+            other.contract_address,
+            *TOKENS[0]
+        ]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    await assert_revert(signer.send_transaction(
+        owner, erc721.contract_address, 'setApprovalForAll', [
+            other.contract_address,
+            TRUE
+        ]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    await assert_revert(signer.send_transaction(
+        owner, erc721.contract_address, 'transferFrom', [
+            owner.contract_address,
+            other.contract_address,
+            *TOKENS[0]
+        ]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    await assert_revert(signer.send_transaction(
+        owner, erc721.contract_address, 'safeTransferFrom', [
+            owner.contract_address,
+            erc721_holder.contract_address,
+            *TOKENS[1],
+            len(DATA),
+            *DATA
+        ]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+    await assert_revert(signer.send_transaction(
+        owner, erc721.contract_address, 'mint', [
+            other.contract_address,
+            *TOKEN_TO_MINT
+        ]),
+        reverted_with="Pausable: contract is paused"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unpause(erc721_minted):
+    erc721, owner, other, erc721_holder = erc721_minted
+
+    # pause
+    await signer.send_transaction(owner, erc721.contract_address, 'pause', [])
+
+    # unpause
+    await signer.send_transaction(owner, erc721.contract_address, 'unpause', [])
+
+    execution_info = await erc721.paused().invoke()
+    assert execution_info.result.paused == FALSE
+
+    await signer.send_transaction(
+        owner, erc721.contract_address, 'approve', [
+            other.contract_address,
+            *TOKENS[0]
+        ]
+    )
+
+    await signer.send_transaction(
+        owner, erc721.contract_address, 'setApprovalForAll', [
+            other.contract_address,
+            TRUE
+        ]
+    )
+
+    await signer.send_transaction(
+        owner, erc721.contract_address, 'transferFrom', [
+            owner.contract_address,
+            other.contract_address,
+            *TOKENS[0]
+        ]
+    )
+
+    await signer.send_transaction(
+        other, erc721.contract_address, 'safeTransferFrom', [
+            owner.contract_address,
+            erc721_holder.contract_address,
+            *TOKENS[1],
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    await signer.send_transaction(
+        owner, erc721.contract_address, 'mint', [
+            other.contract_address,
+            *TOKEN_TO_MINT
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_only_owner(erc721_minted):
+    erc721, owner, other, _ = erc721_minted
+
+    # not-owner pause should revert
+    await assert_revert(
+        signer.send_transaction(
+            other, erc721.contract_address, 'pause', []),
+        reverted_with="Ownable: caller is not the owner"
+    )
+
+    # owner pause
+    await signer.send_transaction(owner, erc721.contract_address, 'pause', [])
+
+    # not-owner unpause should revert
+    await assert_revert(
+        signer.send_transaction(
+            other, erc721.contract_address, 'unpause', []),
+        reverted_with="Ownable: caller is not the owner"
+    )
+
+    # owner unpause
+    await signer.send_transaction(owner, erc721.contract_address, 'unpause', [])

--- a/openzeppelin/tests/token/erc721/test_ERC721_SafeMintable_mock.py
+++ b/openzeppelin/tests/token/erc721/test_ERC721_SafeMintable_mock.py
@@ -1,0 +1,222 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, str_to_felt, ZERO_ADDRESS, INVALID_UINT256, assert_revert,
+    assert_event_emitted, get_contract_def, cached_contract, to_uint
+)
+
+
+signer = Signer(123456789987654321)
+
+# random token id
+TOKEN = to_uint(5042)
+# random data (mimicking bytes in Solidity)
+DATA = [0x42, 0x89, 0x55]
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = get_contract_def('openzeppelin/account/Account.cairo')
+    erc721_def = get_contract_def('tests/mocks/ERC721_SafeMintable_mock.cairo')
+    erc721_holder_def = get_contract_def(
+        'openzeppelin/token/erc721/utils/ERC721_Holder.cairo')
+    unsupported_def = get_contract_def(
+        'openzeppelin/security/initializable.cairo')
+
+    return account_def, erc721_def, erc721_holder_def, unsupported_def
+
+
+@pytest.fixture(scope='module')
+async def erc721_init(contract_defs):
+    account_def, erc721_def, erc721_holder_def, unsupported_def = contract_defs
+    starknet = await Starknet.empty()
+    account1 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    account2 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    erc721 = await starknet.deploy(
+        contract_def=erc721_def,
+        constructor_calldata=[
+            str_to_felt("Non Fungible Token"),  # name
+            str_to_felt("NFT"),                 # ticker
+            account1.contract_address
+        ]
+    )
+    erc721_holder = await starknet.deploy(
+        contract_def=erc721_holder_def,
+        constructor_calldata=[]
+    )
+    unsupported = await starknet.deploy(
+        contract_def=unsupported_def,
+        constructor_calldata=[]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc721,
+        erc721_holder,
+        unsupported
+    )
+
+
+@pytest.fixture
+def erc721_factory(contract_defs, erc721_init):
+    account_def, erc721_def, erc721_holder_def, unsupported_def = contract_defs
+    state, account1, account2, erc721, erc721_holder, unsupported = erc721_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_def, account1)
+    account2 = cached_contract(_state, account_def, account2)
+    erc721 = cached_contract(_state, erc721_def, erc721)
+    erc721_holder = cached_contract(_state, erc721_holder_def, erc721_holder)
+    unsupported = cached_contract(_state, unsupported_def, unsupported)
+
+    return erc721, account1, account2, erc721_holder, unsupported
+
+
+@pytest.mark.asyncio
+async def test_safeMint_to_erc721_supported_contract(erc721_factory):
+    erc721, account, _, erc721_holder, _ = erc721_factory
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'safeMint', [
+            erc721_holder.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    # check balance
+    execution_info = await erc721.balanceOf(erc721_holder.contract_address).call()
+    assert execution_info.result == (to_uint(1),)
+
+    # check owner
+    execution_info = await erc721.ownerOf(TOKEN).call()
+    assert execution_info.result == (erc721_holder.contract_address,)
+
+
+@pytest.mark.asyncio
+async def test_safeMint_emits_event(erc721_factory):
+    erc721, account, _, erc721_holder, _ = erc721_factory
+
+    tx_exec_info = await signer.send_transaction(
+        account, erc721.contract_address, 'safeMint', [
+            erc721_holder.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=erc721.contract_address,
+        name='Transfer',
+        data=[
+            ZERO_ADDRESS,
+            erc721_holder.contract_address,
+            *TOKEN
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeMint_to_account(erc721_factory):
+    erc721, account, recipient, _, _ = erc721_factory
+
+    await signer.send_transaction(
+        account, erc721.contract_address, 'safeMint', [
+            recipient.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]
+    )
+
+    # check balance
+    execution_info = await erc721.balanceOf(recipient.contract_address).call()
+    assert execution_info.result == (to_uint(1),)
+
+    # check owner
+    execution_info = await erc721.ownerOf(TOKEN).call()
+    assert execution_info.result == (recipient.contract_address,)
+
+
+@pytest.mark.asyncio
+async def test_safeMint_to_zero_address(erc721_factory):
+    erc721, account, _, _, _ = erc721_factory
+
+    # to zero address should be rejected
+    await assert_revert(signer.send_transaction(
+        account, erc721.contract_address, 'safeMint', [
+            ZERO_ADDRESS,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]),
+        reverted_with="ERC721: cannot mint to the zero address"
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeMint_from_zero_address(erc721_factory):
+    erc721, _, _, erc721_holder, _ = erc721_factory
+
+    # Caller address is `0` when not using an account contract
+    await assert_revert(
+        erc721.safeMint(
+            erc721_holder.contract_address,
+            TOKEN,
+            DATA
+        ).invoke(),
+        reverted_with="Ownable: caller is not the owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeMint_from_not_owner(erc721_factory):
+    erc721, _, other, erc721_holder, _ = erc721_factory
+
+    await assert_revert(signer.send_transaction(
+        other, erc721.contract_address, 'safeMint', [
+            erc721_holder.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ]),
+        reverted_with="Ownable: caller is not the owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeMint_to_unsupported_contract(erc721_factory):
+    erc721, account, _, _, unsupported = erc721_factory
+
+    await assert_revert(signer.send_transaction(
+        account, erc721.contract_address, 'safeMint', [
+            unsupported.contract_address,
+            *TOKEN,
+            len(DATA),
+            *DATA
+        ])
+    )
+
+
+@pytest.mark.asyncio
+async def test_safeMint_invalid_uint256(erc721_factory):
+    erc721, account, recipient, _, _ = erc721_factory
+
+    await assert_revert(signer.send_transaction(
+        account, erc721.contract_address, 'safeMint', [
+            recipient.contract_address,
+            *INVALID_UINT256,
+            len(DATA),
+            *DATA
+        ]),
+        reverted_with="ERC721: token_id is not a valid Uint256"
+    )

--- a/openzeppelin/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
+++ b/openzeppelin/tests/token/erc721_enumerable/test_ERC721_Enumerable_Mintable_Burnable.py
@@ -1,0 +1,311 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, str_to_felt, MAX_UINT256, get_contract_def, cached_contract,
+    TRUE, assert_revert, to_uint, sub_uint, add_uint
+)
+
+
+signer = Signer(123456789987654321)
+
+# random token IDs
+TOKENS = [
+    to_uint(5042), to_uint(793), to_uint(321), MAX_UINT256, to_uint(8)
+]
+# total tokens as uint
+TOTAL_TOKENS = to_uint(len(TOKENS))
+# random user address
+RECIPIENT = 555
+# random data (mimicking bytes in Solidity)
+DATA = [0x42, 0x89, 0x55]
+# selector id
+ENUMERABLE_INTERFACE_ID = 0x780e9d63
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = get_contract_def('openzeppelin/account/Account.cairo')
+    erc721_def = get_contract_def(
+        'openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo')
+
+    return account_def, erc721_def
+
+
+@pytest.fixture(scope='module')
+async def erc721_init(contract_defs):
+    account_def, erc721_def = contract_defs
+    starknet = await Starknet.empty()
+    account1 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    account2 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    erc721 = await starknet.deploy(
+        contract_def=erc721_def,
+        constructor_calldata=[
+            str_to_felt("Non Fungible Token"),  # name
+            str_to_felt("NFT"),                 # ticker
+            account1.contract_address           # owner
+        ]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc721
+    )
+
+
+@pytest.fixture
+def erc721_factory(contract_defs, erc721_init):
+    account_def, erc721_def = contract_defs
+    state, account1, account2, erc721 = erc721_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_def, account1)
+    account2 = cached_contract(_state, account_def, account2)
+    erc721 = cached_contract(_state, erc721_def, erc721)
+
+    return erc721, account1, account2
+
+
+@pytest.fixture
+async def erc721_minted(erc721_factory):
+    erc721, account, account2 = erc721_factory
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    return erc721, account, account2
+
+
+#
+# supportsInterface
+#
+
+
+@pytest.mark.asyncio
+async def test_supportsInterface(erc721_factory):
+    erc721, _, _ = erc721_factory
+
+    execution_info = await erc721.supportsInterface(ENUMERABLE_INTERFACE_ID).invoke()
+    assert execution_info.result == (TRUE,)
+
+#
+# totalSupply
+#
+
+
+@pytest.mark.asyncio
+async def test_totalSupply(erc721_minted):
+    erc721, _, _ = erc721_minted
+
+    execution_info = await erc721.totalSupply().invoke()
+    assert execution_info.result == (TOTAL_TOKENS,)
+
+
+#
+# tokenOfOwnerByIndex
+#
+
+
+@pytest.mark.asyncio
+async def test_tokenOfOwnerByIndex(erc721_minted):
+    erc721, account, _ = erc721_minted
+
+    # check index
+    for i in range(0, len(TOKENS)):
+        execution_info = await erc721.tokenOfOwnerByIndex(
+            account.contract_address, to_uint(i)).invoke()
+        assert execution_info.result == (TOKENS[i],)
+
+
+@pytest.mark.asyncio
+async def test_tokenOfOwnerByIndex_greater_than_supply(erc721_minted):
+    erc721, account, _ = erc721_minted
+
+    tokens_plus_one = add_uint(TOTAL_TOKENS, to_uint(1))
+
+    await assert_revert(
+        erc721.tokenOfOwnerByIndex(
+            account.contract_address, tokens_plus_one).invoke(),
+        reverted_with="ERC721_Enumerable: owner index out of bounds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokenOfOwnerByIndex_owner_with_no_tokens(erc721_minted):
+    erc721, _, _ = erc721_minted
+
+    await assert_revert(
+        erc721.tokenOfOwnerByIndex(RECIPIENT, to_uint(1)).invoke(),
+        reverted_with="ERC721_Enumerable: owner index out of bounds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokenOfOwnerByIndex_transfer_all_tokens(erc721_minted):
+    erc721, account, other = erc721_minted
+
+    # transfer all tokens
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'transferFrom', [
+                account.contract_address,
+                other.contract_address,
+                *token
+            ]
+        )
+
+    execution_info = await erc721.balanceOf(other.contract_address).invoke()
+    assert execution_info.result == (TOTAL_TOKENS,)
+
+    for i in range(0, len(TOKENS)):
+        execution_info = await erc721.tokenOfOwnerByIndex(other.contract_address, to_uint(i)).invoke()
+        assert execution_info.result == (TOKENS[i],)
+
+    execution_info = await erc721.balanceOf(account.contract_address).invoke()
+    assert execution_info.result == (to_uint(0),)
+
+    # check that queries to old owner's token ownership reverts since index is less
+    # than the target's balance
+    await assert_revert(erc721.tokenOfOwnerByIndex(
+        account.contract_address, to_uint(0)).invoke(),
+        reverted_with="ERC721_Enumerable: owner index out of bounds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokenOfOwnerByIndex_safe_transfer_all_tokens(erc721_minted):
+    erc721, account, other = erc721_minted
+
+    # safe transfer all tokens
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                other.contract_address,
+                *token,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+    execution_info = await erc721.balanceOf(other.contract_address).invoke()
+    assert execution_info.result == (TOTAL_TOKENS,)
+
+    for i in range(0, len(TOKENS)):
+        execution_info = await erc721.tokenOfOwnerByIndex(other.contract_address, to_uint(i)).invoke()
+        assert execution_info.result == (TOKENS[i],)
+
+    execution_info = await erc721.balanceOf(account.contract_address).invoke()
+    assert execution_info.result == (to_uint(0),)
+
+    # check that queries to old owner's token ownership reverts since index is less
+    # than the target's balance
+    await assert_revert(erc721.tokenOfOwnerByIndex(
+        account.contract_address, to_uint(0)).invoke(),
+        reverted_with="ERC721_Enumerable: owner index out of bounds"
+    )
+
+
+#
+# tokenByIndex
+#
+
+
+@pytest.mark.asyncio
+async def test_tokenByIndex(erc721_minted):
+    erc721, _, _ = erc721_minted
+
+    for i in range(0, len(TOKENS)):
+        execution_info = await erc721.tokenByIndex(to_uint(i)).invoke()
+        assert execution_info.result == (TOKENS[i],)
+
+
+@pytest.mark.asyncio
+async def test_tokenByIndex_greater_than_supply(erc721_minted):
+    erc721, _, _ = erc721_minted
+
+    await assert_revert(
+        erc721.tokenByIndex(to_uint(5)).invoke(),
+        reverted_with="ERC721_Enumerable: global index out of bounds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokenByIndex_burn_last_token(erc721_minted):
+    erc721, account, _ = erc721_minted
+
+    tokens_minus_one = sub_uint(TOTAL_TOKENS, to_uint(1))
+
+    # burn last token
+    await signer.send_transaction(
+        account, erc721.contract_address, 'burn', [
+            *TOKENS[4]]
+    )
+
+    execution_info = await erc721.totalSupply().invoke()
+    assert execution_info.result == (tokens_minus_one,)
+
+    for i in range(0, 4):
+        execution_info = await erc721.tokenByIndex(to_uint(i)).invoke()
+        assert execution_info.result == (TOKENS[i],)
+
+    await assert_revert(
+        erc721.tokenByIndex(tokens_minus_one).invoke(),
+        reverted_with="ERC721_Enumerable: global index out of bounds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokenByIndex_burn_first_token(erc721_minted):
+    erc721, account, _ = erc721_minted
+
+    # burn first token
+    await signer.send_transaction(
+        account, erc721.contract_address, 'burn', [
+            *TOKENS[0]]
+    )
+
+    # TOKEN[0] should be burnt and TOKEN[4] should be swapped
+    # to TOKEN[0]'s index
+    new_token_order = [TOKENS[4], TOKENS[1], TOKENS[2], TOKENS[3]]
+    for i in range(0, 3):
+        execution_info = await erc721.tokenByIndex(to_uint(i)).invoke()
+        assert execution_info.result == (new_token_order[i],)
+
+
+@pytest.mark.asyncio
+async def test_tokenByIndex_burn_and_mint(erc721_minted):
+    erc721, account, _ = erc721_minted
+
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [
+                *token]
+        )
+
+    execution_info = await erc721.totalSupply().invoke()
+    assert execution_info.result == (to_uint(0),)
+
+    await assert_revert(
+        erc721.tokenByIndex(to_uint(0)).invoke(),
+        reverted_with="ERC721_Enumerable: global index out of bounds"
+    )
+
+    # mint new tokens
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    for i in range(0, len(TOKENS)):
+        execution_info = await erc721.tokenByIndex(to_uint(i)).invoke()
+        assert execution_info.result == (TOKENS[i],)

--- a/openzeppelin/tests/upgrades/test_Proxy.py
+++ b/openzeppelin/tests/upgrades/test_Proxy.py
@@ -1,0 +1,109 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, assert_revert, get_contract_def, cached_contract
+)
+
+
+# random value
+VALUE = 123
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = get_contract_def('openzeppelin/account/Account.cairo')
+    implementation_def = get_contract_def(
+        'tests/mocks/proxiable_implementation.cairo'
+    )
+    proxy_def = get_contract_def('openzeppelin/upgrades/Proxy.cairo')
+
+    return account_def, implementation_def, proxy_def
+
+
+@pytest.fixture(scope='module')
+async def proxy_init(contract_defs):
+    account_def, implementation_def, proxy_def = contract_defs
+    starknet = await Starknet.empty()
+    account = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    implementation = await starknet.deploy(
+        contract_def=implementation_def,
+        constructor_calldata=[]
+    )
+    proxy = await starknet.deploy(
+        contract_def=proxy_def,
+        constructor_calldata=[implementation.contract_address]
+    )
+    return (
+        starknet.state,
+        account,
+        implementation,
+        proxy
+    )
+
+
+@pytest.fixture
+def proxy_factory(contract_defs, proxy_init):
+    account_def, implementation_def, proxy_def = contract_defs
+    state, account, implementation, proxy = proxy_init
+    _state = state.copy()
+    account = cached_contract(_state, account_def, account)
+    implementation = cached_contract(
+        _state,
+        implementation_def,
+        implementation
+    )
+    proxy = cached_contract(_state, proxy_def, proxy)
+
+    return account, implementation, proxy
+
+
+@pytest.mark.asyncio
+async def test_constructor_sets_correct_implementation(proxy_factory):
+    account, implementation, proxy = proxy_factory
+
+    execution_info = await signer.send_transaction(
+        account, proxy.contract_address, 'get_implementation', []
+    )
+    assert execution_info.result.response == [implementation.contract_address]
+
+
+@pytest.mark.asyncio
+async def test_initializer(proxy_factory):
+    account, _, proxy = proxy_factory
+
+    await signer.send_transaction(
+        account, proxy.contract_address, 'initializer', [
+            account.contract_address]
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_fallback(proxy_factory):
+    account, _, proxy = proxy_factory
+
+    # set value through proxy
+    await signer.send_transaction(
+        account, proxy.contract_address, 'set_value', [VALUE]
+    )
+
+    # get value through proxy
+    execution_info = execution_info = await signer.send_transaction(
+        account, proxy.contract_address, 'get_value', []
+    )
+    assert execution_info.result.response == [VALUE]
+
+
+@pytest.mark.asyncio
+async def test_fallback_when_selector_does_not_exist(proxy_factory):
+    account, _, proxy = proxy_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            account, proxy.contract_address, 'bad_selector', []
+        )
+    )

--- a/openzeppelin/tests/upgrades/test_upgrades.py
+++ b/openzeppelin/tests/upgrades/test_upgrades.py
@@ -1,0 +1,274 @@
+import pytest
+from starkware.starknet.testing.starknet import Starknet
+from utils import (
+    Signer, assert_revert, assert_event_emitted, get_contract_def, cached_contract
+)
+
+
+# random value
+VALUE_1 = 123
+VALUE_2 = 987
+
+signer = Signer(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_def = get_contract_def('openzeppelin/account/Account.cairo')
+    v1_def = get_contract_def('tests/mocks/upgrades_v1_mock.cairo')
+    v2_def = get_contract_def('tests/mocks/upgrades_v2_mock.cairo')
+    proxy_def = get_contract_def('openzeppelin/upgrades/Proxy.cairo')
+
+    return account_def, v1_def, v2_def, proxy_def
+
+
+@pytest.fixture(scope='module')
+async def proxy_init(contract_defs):
+    account_def, dummy_v1_def, dummy_v2_def, proxy_def = contract_defs
+    starknet = await Starknet.empty()
+    account1 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    account2 = await starknet.deploy(
+        contract_def=account_def,
+        constructor_calldata=[signer.public_key]
+    )
+    v1 = await starknet.deploy(
+        contract_def=dummy_v1_def,
+        constructor_calldata=[]
+    )
+    v2 = await starknet.deploy(
+        contract_def=dummy_v2_def,
+        constructor_calldata=[]
+    )
+    proxy = await starknet.deploy(
+        contract_def=proxy_def,
+        constructor_calldata=[v1.contract_address]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        v1,
+        v2,
+        proxy
+    )
+
+
+@pytest.fixture
+def proxy_factory(contract_defs, proxy_init):
+    account_def, dummy_v1_def, dummy_v2_def, proxy_def = contract_defs
+    state, account1, account2, v1, v2, proxy = proxy_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_def, account1)
+    account2 = cached_contract(_state, account_def, account2)
+    v1 = cached_contract(_state, dummy_v1_def, v1)
+    v2 = cached_contract(_state, dummy_v2_def, v2)
+    proxy = cached_contract(_state, proxy_def, proxy)
+
+    return account1, account2, v1, v2, proxy
+
+
+@pytest.fixture
+async def after_upgrade(proxy_factory):
+    admin, other, v1, v2, proxy = proxy_factory
+
+    # initialize
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+    # set value
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'set_value_1', [
+            VALUE_1
+        ]
+    )
+
+    # upgrade
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            v2.contract_address
+        ]
+    )
+
+    return admin, other, v1, v2, proxy
+
+
+@pytest.mark.asyncio
+async def test_initializer(proxy_factory):
+    admin, _, _, _, proxy = proxy_factory
+
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_initializer_already_initialized(proxy_factory):
+    admin, _, _, _, proxy = proxy_factory
+
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+    await assert_revert(
+        signer.send_transaction(
+            admin, proxy.contract_address, 'initializer', [
+                admin.contract_address
+            ]
+        ),
+        reverted_with='Proxy: contract already initialized'
+    )
+
+
+@pytest.mark.asyncio
+async def test_upgrade(proxy_factory):
+    admin, _, _, v2, proxy = proxy_factory
+
+    # initialize implementation
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+    # set value
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'set_value_1', [
+            VALUE_1
+        ]
+    )
+
+    # check value
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_value_1', []
+    )
+    assert execution_info.result.response == [VALUE_1, ]
+
+    # upgrade
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            v2.contract_address
+        ]
+    )
+
+    # check value
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_value_1', []
+    )
+    assert execution_info.result.response == [VALUE_1, ]
+
+
+@pytest.mark.asyncio
+async def test_upgrade_event(proxy_factory):
+    admin, _, _, v2, proxy = proxy_factory
+
+    # initialize implementation
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+    # upgrade
+    tx_exec_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'upgrade', [
+            v2.contract_address
+        ]
+    )
+
+    # check event
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=proxy.contract_address,
+        name='Upgraded',
+        data=[
+            v2.contract_address
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_upgrade_from_non_admin(proxy_factory):
+    admin, non_admin, _, v2, proxy = proxy_factory
+
+    # initialize implementation
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'initializer', [
+            admin.contract_address
+        ]
+    )
+
+    # upgrade should revert
+    await assert_revert(
+        signer.send_transaction(
+            non_admin, proxy.contract_address, 'upgrade', [
+                v2.contract_address
+            ]
+        ),
+        reverted_with="Proxy: caller is not admin"
+    )
+
+
+# Using `after_upgrade` fixture henceforth
+@pytest.mark.asyncio
+async def test_implementation_v2(after_upgrade):
+    admin, _, _, v2, proxy = after_upgrade
+
+    # check implementation address
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_implementation', []
+    )
+    assert execution_info.result.response == [v2.contract_address]
+
+    # check admin
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_admin', []
+    )
+    assert execution_info.result.response == [admin.contract_address]
+
+    # check value
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_value_1', []
+    )
+    assert execution_info.result.response == [VALUE_1, ]
+
+
+@pytest.mark.asyncio
+async def test_set_admin(after_upgrade):
+    admin, new_admin, _, _, proxy = after_upgrade
+
+    # change admin
+    await signer.send_transaction(
+        admin, proxy.contract_address, 'set_admin', [
+            new_admin.contract_address
+        ]
+    )
+
+    # check admin
+    execution_info = await signer.send_transaction(
+        admin, proxy.contract_address, 'get_admin', []
+    )
+    assert execution_info.result.response == [new_admin.contract_address]
+
+
+@pytest.mark.asyncio
+async def test_set_admin_from_non_admin(after_upgrade):
+    _, non_admin, _, _, proxy = after_upgrade
+
+    # change admin should revert
+    await assert_revert(
+        signer.send_transaction(
+            non_admin, proxy.contract_address, 'set_admin', [
+                non_admin.contract_address
+            ]
+        )
+    )

--- a/openzeppelin/tests/utils.py
+++ b/openzeppelin/tests/utils.py
@@ -1,0 +1,208 @@
+"""Utilities for testing Cairo contracts."""
+
+from pathlib import Path
+import math
+from starkware.cairo.common.hash_state import compute_hash_on_elements
+from starkware.crypto.signature.signature import private_to_stark_key, sign
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starkware_utils.error_handling import StarkException
+from starkware.starknet.testing.starknet import StarknetContract
+from starkware.starknet.business_logic.transaction_execution_objects import Event
+from starkware.starknet.core.os.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
+from starkware.starknet.definitions.general_config import StarknetChainId
+
+MAX_UINT256 = (2**128 - 1, 2**128 - 1)
+INVALID_UINT256 = (MAX_UINT256[0] + 1, MAX_UINT256[1])
+ZERO_ADDRESS = 0
+TRUE = 1
+FALSE = 0
+
+TRANSACTION_VERSION = 0
+
+
+_root = Path(__file__).parent.parent
+
+
+def contract_path(name):
+    if name.startswith("tests/"):
+        return str(_root / name)
+    else:
+        return str(_root / "src" / name)
+
+
+def str_to_felt(text):
+    b_text = bytes(text, "ascii")
+    return int.from_bytes(b_text, "big")
+
+
+def felt_to_str(felt):
+    b_felt = felt.to_bytes(31, "big")
+    return b_felt.decode()
+
+
+def uint(a):
+    return(a, 0)
+
+
+def to_uint(a):
+    """Takes in value, returns uint256-ish tuple."""
+    return (a & ((1 << 128) - 1), a >> 128)
+
+
+def from_uint(uint):
+    """Takes in uint256-ish tuple, returns value."""
+    return uint[0] + (uint[1] << 128)
+
+
+def add_uint(a, b):
+    """Returns the sum of two uint256-ish tuples."""
+    a = from_uint(a)
+    b = from_uint(b)
+    c = a + b
+    return to_uint(c)
+
+
+def sub_uint(a, b):
+    """Returns the difference of two uint256-ish tuples."""
+    a = from_uint(a)
+    b = from_uint(b)
+    c = a - b
+    return to_uint(c)
+
+
+def mul_uint(a, b):
+    """Returns the product of two uint256-ish tuples."""
+    a = from_uint(a)
+    b = from_uint(b)
+    c = a * b
+    return to_uint(c)
+
+
+def div_rem_uint(a, b):
+    """Returns the quotient and remainder of two uint256-ish tuples."""
+    a = from_uint(a)
+    b = from_uint(b)
+    c = math.trunc(a / b)
+    m = a % b
+    return (to_uint(c), to_uint(m))
+
+
+async def assert_revert(fun, reverted_with=None):
+    try:
+        await fun
+        assert False
+    except StarkException as err:
+        _, error = err.args
+        if reverted_with is not None:
+            assert reverted_with in error['message']
+
+
+def assert_event_emitted(tx_exec_info, from_address, name, data):
+    assert Event(
+        from_address=from_address,
+        keys=[get_selector_from_name(name)],
+        data=data,
+    ) in tx_exec_info.raw_events
+
+
+def get_contract_def(path):
+    """Returns the contract definition from the contract path"""
+    path = contract_path(path)
+    contract_def = compile_starknet_files(
+        files=[path],
+        debug_info=True
+    )
+    return contract_def
+
+
+def cached_contract(state, definition, deployed):
+    """Returns the cached contract"""
+    contract = StarknetContract(
+        state=state,
+        abi=definition.abi,
+        contract_address=deployed.contract_address,
+        deploy_execution_info=deployed.deploy_execution_info
+    )
+    return contract
+
+
+class Signer():
+    """
+    Utility for sending signed transactions to an Account on Starknet.
+
+    Parameters
+    ----------
+
+    private_key : int
+
+    Examples
+    ---------
+    Constructing a Signer object
+
+    >>> signer = Signer(1234)
+
+    Sending a transaction
+
+    >>> await signer.send_transaction(account,
+                                      account.contract_address,
+                                      'set_public_key',
+                                      [other.public_key]
+                                     )
+
+    """
+
+    def __init__(self, private_key):
+        self.private_key = private_key
+        self.public_key = private_to_stark_key(private_key)
+
+    def sign(self, message_hash):
+        return sign(msg_hash=message_hash, priv_key=self.private_key)
+
+    async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
+        return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
+
+    async def send_transactions(self, account, calls, nonce=None, max_fee=0):
+        if nonce is None:
+            execution_info = await account.get_nonce().call()
+            nonce, = execution_info.result
+
+        calls_with_selector = [
+            (call[0], get_selector_from_name(call[1]), call[2]) for call in calls]
+        (call_array, calldata) = from_call_to_call_array(calls)
+
+        message_hash = get_transaction_hash(account.contract_address, call_array, calldata, nonce, max_fee)
+        sig_r, sig_s = self.sign(message_hash)
+
+        return await account.__execute__(call_array, calldata, nonce).invoke(signature=[sig_r, sig_s])
+
+
+def from_call_to_call_array(calls):
+    call_array = []
+    calldata = []
+    for i, call in enumerate(calls):
+        assert len(call) == 3, "Invalid call parameters"
+        entry = (call[0], get_selector_from_name(
+            call[1]), len(calldata), len(call[2]))
+        call_array.append(entry)
+        calldata.extend(call[2])
+    return (call_array, calldata)
+
+def get_transaction_hash(account, call_array, calldata, nonce, max_fee):
+    execute_calldata = [
+        len(call_array),
+        *[x for t in call_array for x in t],
+        len(calldata),
+        *calldata,
+        nonce]
+
+    return calculate_transaction_hash_common(
+        TransactionHashPrefix.INVOKE,
+        TRANSACTION_VERSION,
+        account,
+        get_selector_from_name('__execute__'),
+        execute_calldata,
+        max_fee,
+        StarknetChainId.TESTNET.value,
+        []
+    )

--- a/openzeppelin/tox.ini
+++ b/openzeppelin/tox.ini
@@ -1,0 +1,32 @@
+[tox]
+minversion = 3.15
+envlist = default
+isolated_build = True
+
+[testenv]
+description = Invoke pytest to run automated tests
+setenv =
+    TOXINIDIR = {toxinidir}
+passenv =
+    HOME
+    PYTHONPATH
+deps =
+    cairo-lang
+extras =
+    testing
+commands =
+    pytest {posargs}
+
+[testenv:build]
+description = Build the package in isolation according to PEP517, see https://github.com/pypa/build
+skip_install = True
+changedir = {toxinidir}
+deps =
+    build[virtualenv]
+    twine
+commands =
+    python -m build . -o dist
+    python -m twine check --strict dist/*
+
+[pytest]
+asyncio_mode=auto


### PR DESCRIPTION
This adds the OZ base repo in a top-level dir as a subtree.

This allows:
- Composing the OZ contracts into bespoke contracts nested in the contracts folder
- Easy fetching and updating of the OZ files as they change

The reasoning for this dir to be at the top level was so the paths within the OZ file would resolve without any other changes.

