### PR TITLE
ci: setup cairo linting, bump to cairo 0.8.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Python setup
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: pip
+          cache-dependency-path: '**/requirements.txt'
+
+      - name: Env setup
+        run: pip install -r requirements.txt
+
+      - name: Lint Cairo code
+        run: find contracts -type f -name '*.cairo' | xargs cairo-format -c

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ attrs==21.2.0
 base58==2.1.1
 bitarray==1.2.2
 cachetools==4.2.4
-cairo-lang==0.8.0
+cairo-lang==0.8.1
 cairo-nile==0.5.0
 certifi==2021.10.8
 charset-normalizer==2.0.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from starkware.starknet.business_logic.state import BlockInfo
+from starkware.starknet.business_logic.state.state import BlockInfo
 from starkware.starknet.testing.starknet import Starknet, StarknetContract
 from starkware.starknet.services.api.contract_definition import ContractDefinition
 from starkware.starknet.compiler.compile import compile_starknet_files


### PR DESCRIPTION
This PR adds a GH Action to lint *.cairo files. It also bumps cairo-lang to [v0.8.1](https://github.com/starkware-libs/cairo-lang/releases/tag/v0.8.1) which was released a couple of days ago and actually has significant changes to the formatter.