### PR TITLE
ci: adding Amarna static analysis for Cairo

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,36 @@
+name: Cairo static analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Python setup
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: pip
+          cache-dependency-path: '**/requirements.txt'
+
+      - name: Env setup
+        run: pip install -r requirements.txt
+
+      - name: Install Amarna
+        run: git clone https://github.com/crytic/amarna.git && cd amarna && pip install -e .
+
+      - name: Run Amarna static analysis
+        run: amarna contracts/ -o out.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: out.sarif


### PR DESCRIPTION
Trail of Bits [just released](https://blog.trailofbits.com/2022/04/20/amarna-static-analysis-for-cairo-programs/) Amarna, a static analysis tool for Cairo (as is Slither for Solidity).

This PR adds a new CI job to run the analysis tool on our Cairo code.