### PR TITLE
Deploy Enhancements & Account Management 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 
 # vscode project settings
 .vscode/
+
+node_modules

--- a/openzeppelin/account/library.cairo
+++ b/openzeppelin/account/library.cairo
@@ -117,7 +117,6 @@ end
 # Business logic
 #
 
-@view
 func Account_is_valid_signature{
         syscall_ptr : felt*, 
         pedersen_ptr : HashBuiltin*,

--- a/tasks/deploy_account.ts
+++ b/tasks/deploy_account.ts
@@ -1,15 +1,24 @@
 import { Provider, ec } from "starknet";
 import fs from "fs";
+import { config as dotenvConfig } from "dotenv";
+import { resolve } from "path";
+
 import { getPathBase } from "./helpers";
+dotenvConfig({ path: resolve(__dirname, "../.env") });
 
 const DEPLOYMENT_PATH_BASE = getPathBase();
 
 export default async function deployAccount() {
+
+  const accountName = process.env.ACCOUNT_NAME || `OwnerAccount`;
+
+  console.log("Deploying account", accountName)
+
   if (!fs.existsSync(DEPLOYMENT_PATH_BASE)) {
     await fs.promises.mkdir(DEPLOYMENT_PATH_BASE, { recursive: true })
   }
 
-  if (fs.existsSync(`${DEPLOYMENT_PATH_BASE}/OwnerAccount.json`)) {
+  if (fs.existsSync(`${DEPLOYMENT_PATH_BASE}/${accountName}.json`)) {
     console.log("Deployment already exists")
     return
   }
@@ -30,7 +39,7 @@ export default async function deployAccount() {
     ]
   })
 
-  fs.writeFileSync(`${DEPLOYMENT_PATH_BASE}/OwnerAccount.json`, JSON.stringify({
+  fs.writeFileSync(`${DEPLOYMENT_PATH_BASE}/${accountName}.json`, JSON.stringify({
     ...result,
     public_key: starkKey
   }))

--- a/tasks/helpers/index.ts
+++ b/tasks/helpers/index.ts
@@ -7,7 +7,9 @@ import { resolve } from "path";
 
 dotenvConfig({ path: resolve(__dirname, "../../.env") });
 
-export const DEPLOYMENT_PATH_BASE = "./deployments/starknet";
+// Deployments for different applications can provide a separate base
+// with an environment variable.
+export const DEPLOYMENT_PATH_BASE = process.env.DEPLOY_BASE || "./deployments/starknet";
 
 const network: any = process.env.NETWORK || "georli-alpha"
 export const provider = new Provider(network === "local" ? { baseUrl: "http://127.0.0.1:5000/" } : { network })
@@ -172,7 +174,7 @@ export function getSigner() {
 export async function sendtx(data: any) {
   try {
     const res = await getSigner().execute(data, undefined, {
-            maxFee: '250000000000000000000' // Extra buffer
+            maxFee: 0
         })
 
     console.log(res)


### PR DESCRIPTION
- Desiege needed a separate deployments directory when running scripts. Added support for `DEPLOYMENT_BASE` env var in a backwards compatible way so that this can be configured. Also added `ACCOUNT_NAME` env so multiple accounts can be deployed and used for further deployments.
- Refactored `tasks/helpers.ts` with more consistent account retrieval method, maintains backwards compatibility

Extras
- Added `node_modules` to gitignore since this repo also serves as a JS task exec environment
- The latest OZ Account contract had very small diff to remove a duplicated `@view` function for signature checking