### PR TITLE
refactor: squad packing

### DIFF
--- a/contracts/settling_game/L06_Combat.cairo
+++ b/contracts/settling_game/L06_Combat.cairo
@@ -442,6 +442,7 @@ func hit_troop{range_check_ptr}(t : Troop, hits : felt) -> (
     if kills_troop == 1:
         # t.vitality <= hits
         let ht = Troop(
+            id=t.id,
             type=t.type,
             tier=t.tier,
             agility=t.agility,
@@ -455,6 +456,7 @@ func hit_troop{range_check_ptr}(t : Troop, hits : felt) -> (
     else:
         # t.vitality > hits
         let ht = Troop(
+            id=t.id,
             type=t.type,
             tier=t.tier,
             agility=t.agility,

--- a/contracts/settling_game/L06_Combat.cairo
+++ b/contracts/settling_game/L06_Combat.cairo
@@ -55,7 +55,7 @@ func CombatOutcome_1(attacking_realm_id : Uint256, defending_realm_id : Uint256,
 end
 
 @event
-func CombatStep_1(
+func CombatStep_2(
     attacking_realm_id : Uint256,
     defending_realm_id : Uint256,
     attacking_squad : Squad,
@@ -66,7 +66,7 @@ func CombatStep_1(
 end
 
 @event
-func BuildTroops_1(
+func BuildTroops_2(
     squad : Squad, troop_ids_len : felt, troop_ids : felt*, realm_id : Uint256, slot : felt
 ):
 end
@@ -175,7 +175,7 @@ func build_squad_from_troops_in_realm{
     let (squad) = COMBAT.add_troops_to_squad(current_squad, troop_ids_len, troop_ids)
     update_squad_in_realm(squad, realm_id, slot)
 
-    BuildTroops_1.emit(squad, troop_ids_len, troop_ids, realm_id, slot)
+    BuildTroops_2.emit(squad, troop_ids_len, troop_ids, realm_id, slot)
 
     return ()
 end
@@ -321,7 +321,7 @@ func attack{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : HashBuiltin*}(
     tempvar pedersen_ptr = pedersen_ptr
 
     let (d_after_attack) = hit_squad(d, hit_points)
-    CombatStep_1.emit(attacking_realm_id, defending_realm_id, a, d, attack_type, hit_points)
+    CombatStep_2.emit(attacking_realm_id, defending_realm_id, a, d, attack_type, hit_points)
     return (d_after_attack)
 end
 

--- a/contracts/settling_game/utils/game_structs.cairo
+++ b/contracts/settling_game/utils/game_structs.cairo
@@ -298,6 +298,10 @@ namespace TroopId:
     const Mage = 14
     const Arcanist = 15
     const GrandMarshal = 16
+    # IMPORTANT: if you're adding to this enum
+    # make sure the SIZE is one greater than the
+    # maximal value; certain algorithms depend on that
+    const SIZE = 17
 end
 
 namespace TroopType:
@@ -307,6 +311,7 @@ namespace TroopType:
 end
 
 struct Troop:
+    member id : felt  # TroopId
     member type : felt  # TroopType
     member tier : felt
     member agility : felt
@@ -352,16 +357,11 @@ struct Squad:
 end
 
 struct PackedSquad:
-    # one packed troop fits into 7 bytes
-    # one felt is ~31 bytes -> can hold 4 troops
-    # a squad has 25 troops -> fits into 7 felts when packed
-    member p1 : felt  # packed Troops t1_1 ... t1_4
-    member p2 : felt  # packed Troops t1_5 ... t1_8
-    member p3 : felt  # packed Troops t1_9 ... t1_12
-    member p4 : felt  # packed Troops t1_13 ... t1_16
-    member p5 : felt  # packed Troops t2_1 ... t2_4
-    member p6 : felt  # packed Troops t2_5 ... t2_8
-    member p7 : felt  # packed Troop t3_1
+    # one packed troop fits into 2 bytes (troop ID + vitality)
+    # one felt is ~31 bytes -> can hold 15 troops
+    # a squad has 25 troops -> fits into 2 felts when packed
+    member p1 : felt  # packed Troops t1_1 ... t1_15
+    member p2 : felt  # packed Troops t1_16 ... t3_1
 end
 
 struct SquadStats:

--- a/tests/settling_game/06_combat_test.py
+++ b/tests/settling_game/06_combat_test.py
@@ -7,25 +7,25 @@ import struct
 import pytest
 from starkware.starkware_utils.error_handling import StarkException
 
-from .game_structs import Cost, Troop, Squad, PackedSquad, ResourceIds, TroopId, TROOP_COSTS
+from .game_structs import Troop, Squad, PackedSquad, ResourceIds, TroopId, TROOP_COSTS
 
-EMPTY_TROOP = Troop(0, 0, 0, 0, 0, 0, 0)
-WATCHMAN = Troop(1, 1, 1, 1, 3, 4, 1)
-GUARD = Troop(1, 2, 2, 2, 6, 8, 2)
-GUARD_CAPTAIN = Troop(1, 3, 4, 4, 12, 16, 4)
-SQUIRE = Troop(1, 1, 1, 4, 1, 1, 3)
-KNIGHT = Troop(1, 2, 2, 8, 2, 2, 6)
-KNIGHT_COMMANDER = Troop(1, 3, 4, 16, 4, 4, 12)
-SCOUT = Troop(2, 1, 4, 3, 1, 1, 1)
-ARCHER = Troop(2, 2, 8, 6, 2, 2, 2)
-SNIPER = Troop(2, 3, 16, 12, 4, 4, 4)
-SCORPIO = Troop(3, 1, 1, 4, 1, 3, 1)
-BALLISTA = Troop(3, 2, 2, 8, 2, 6, 2)
-CATAPULT = Troop(3, 3, 4, 16, 4, 12, 4)
-APPRENTICE = Troop(2, 1, 2, 2, 1, 1, 4)
-MAGE = Troop(2, 2, 4, 4, 2, 2, 8)
-ARCANIST = Troop(2, 3, 8, 8, 4, 4, 16)
-GRAND_MARSHAL = Troop(1, 3, 16, 16, 16, 16, 16)
+EMPTY_TROOP = Troop(0, 0, 0, 0, 0, 0, 0, 0)
+WATCHMAN = Troop(TroopId.Watchman, 1, 1, 1, 1, 3, 4, 1)
+GUARD = Troop(TroopId.Guard, 1, 2, 2, 2, 6, 8, 2)
+GUARD_CAPTAIN = Troop(TroopId.GuardCaptain, 1, 3, 4, 4, 12, 16, 4)
+SQUIRE = Troop(TroopId.Squire, 1, 1, 1, 4, 1, 1, 3)
+KNIGHT = Troop(TroopId.Knight, 1, 2, 2, 8, 2, 2, 6)
+KNIGHT_COMMANDER = Troop(TroopId.KnightCommander, 1, 3, 4, 16, 4, 4, 12)
+SCOUT = Troop(TroopId.Scout, 2, 1, 4, 3, 1, 1, 1)
+ARCHER = Troop(TroopId.Archer, 2, 2, 8, 6, 2, 2, 2)
+SNIPER = Troop(TroopId.Sniper, 2, 3, 16, 12, 4, 4, 4)
+SCORPIO = Troop(TroopId.Scorpio, 3, 1, 1, 4, 1, 3, 1)
+BALLISTA = Troop(TroopId.Ballista, 3, 2, 2, 8, 2, 6, 2)
+CATAPULT = Troop(TroopId.Catapult, 3, 3, 4, 16, 4, 12, 4)
+APPRENTICE = Troop(TroopId.Apprentice, 2, 1, 2, 2, 1, 1, 4)
+MAGE = Troop(TroopId.Mage, 2, 2, 4, 4, 2, 2, 8)
+ARCANIST = Troop(TroopId.Arcanist, 2, 3, 8, 8, 4, 4, 16)
+GRAND_MARSHAL = Troop(TroopId.GrandMarshal, 1, 3, 16, 16, 16, 16, 16)
 TROOPS = [
     WATCHMAN,
     GUARD,
@@ -67,50 +67,40 @@ def pack_squad(squad: Squad) -> PackedSquad:
     shift = 0x100
     p1 = (
         pack_troop(squad.t1_1)
-        + pack_troop(squad.t1_2) * shift**7
-        + pack_troop(squad.t1_3) * shift**14
-        + pack_troop(squad.t1_4) * shift**21
+        + pack_troop(squad.t1_2) * shift**2
+        + pack_troop(squad.t1_3) * shift**4
+        + pack_troop(squad.t1_4) * shift**6
+        + pack_troop(squad.t1_5) * shift**8
+        + pack_troop(squad.t1_6) * shift**10
+        + pack_troop(squad.t1_7) * shift**12
+        + pack_troop(squad.t1_8) * shift**14
+        + pack_troop(squad.t1_9) * shift**16
+        + pack_troop(squad.t1_10) * shift**18
+        + pack_troop(squad.t1_11) * shift**20
+        + pack_troop(squad.t1_12) * shift**22
+        + pack_troop(squad.t1_13) * shift**24
+        + pack_troop(squad.t1_14) * shift**26
+        + pack_troop(squad.t1_15) * shift**28
     )
+
     p2 = (
-        pack_troop(squad.t1_5)
-        + pack_troop(squad.t1_6) * shift**7
-        + pack_troop(squad.t1_7) * shift**14
-        + pack_troop(squad.t1_8) * shift**21
-    )
-    p3 = (
-        pack_troop(squad.t1_9)
-        + pack_troop(squad.t1_10) * shift**7
-        + pack_troop(squad.t1_11) * shift**14
-        + pack_troop(squad.t1_12) * shift**21
-    )
-    p4 = (
-        pack_troop(squad.t1_13)
-        + pack_troop(squad.t1_14) * shift**7
-        + pack_troop(squad.t1_15) * shift**14
-        + pack_troop(squad.t1_16) * shift**21
-    )
-
-    p5 = (
-        pack_troop(squad.t2_1)
-        + pack_troop(squad.t2_2) * shift**7
-        + pack_troop(squad.t2_3) * shift**14
-        + pack_troop(squad.t2_4) * shift**21
-    )
-
-    p6 = (
-        pack_troop(squad.t2_5)
-        + pack_troop(squad.t2_6) * shift**7
+        pack_troop(squad.t1_16)
+        + pack_troop(squad.t2_1) * shift**2
+        + pack_troop(squad.t2_2) * shift**4
+        + pack_troop(squad.t2_3) * shift**6
+        + pack_troop(squad.t2_4) * shift**8
+        + pack_troop(squad.t2_5) * shift**10
+        + pack_troop(squad.t2_6) * shift**12
         + pack_troop(squad.t2_7) * shift**14
-        + pack_troop(squad.t2_8) * shift**21
+        + pack_troop(squad.t2_8) * shift**16
+        + pack_troop(squad.t3_1) * shift**18
     )
 
-    p7 = pack_troop(squad.t3_1)
-
-    return PackedSquad(p1, p2, p3, p4, p5, p6, p7)
+    return PackedSquad(p1, p2)
 
 
 def pack_troop(troop: Troop) -> int:
-    return int.from_bytes(struct.pack("<7b", *troop), "little")
+    return int.from_bytes(struct.pack("<2b", *[troop.id, troop.vitality]), "little")
 
 
 @pytest.mark.asyncio
@@ -127,11 +117,24 @@ async def test_get_troop(s06_combat):
 
 
 @pytest.mark.asyncio
+async def test_pack_troop(library_combat_tests):
+    tx = await library_combat_tests.test_pack_troop(GUARD).invoke()
+    assert tx.result.packed == pack_troop(GUARD)
+
+    wounded = Troop(TroopId.Guard, 1, 2, 2, 2, 6, 1, 2)
+    tx = await library_combat_tests.test_pack_troop(wounded).invoke()
+    assert tx.result.packed == pack_troop(wounded)
+
+
+@pytest.mark.asyncio
 async def test_unpack_troop(library_combat_tests):
     for troop in TROOPS:
         packed = pack_troop(troop)
         tx = await library_combat_tests.test_unpack_troop(packed).invoke()
         assert troop == tx.result.t
+
+    tx = await library_combat_tests.test_unpack_troop(0).invoke()
+    assert tx.result.t == (0, 0, 0, 0, 0, 0, 0, 0)
 
 
 @pytest.mark.asyncio
@@ -156,19 +159,24 @@ async def test_pack_squad(library_combat_tests):
 
 
 @pytest.mark.asyncio
-async def test_get_troop_population(library_combat_tests):
-    squad = build_default_squad()
-    packed_squad = pack_squad(squad)
-    tx = await library_combat_tests.test_get_troop_population(packed_squad).invoke()
-    assert tx.result.population == 25
-
-
-@pytest.mark.asyncio
 async def test_unpack_squad(library_combat_tests):
     squad = build_default_squad()
     packed_squad = pack_squad(squad)
     tx = await library_combat_tests.test_unpack_squad(packed_squad).invoke()
     assert tx.result.s == squad
+
+    squad = build_partial_squad(13)
+    packed_squad = pack_squad(squad)
+    tx = await library_combat_tests.test_unpack_squad(packed_squad).invoke()
+    assert tx.result.s == squad
+
+
+@pytest.mark.asyncio
+async def test_get_troop_population(library_combat_tests):
+    squad = build_default_squad()
+    packed_squad = pack_squad(squad)
+    tx = await library_combat_tests.test_get_troop_population(packed_squad).invoke()
+    assert tx.result.population == 25
 
 
 @pytest.mark.asyncio
@@ -329,7 +337,7 @@ async def test_remove_troop_from_squad(library_combat_tests):
 
 @pytest.mark.asyncio
 async def test_find_first_free_troop_slot_in_squad(library_combat_tests):
-    troop_size = 7  # Cairo's Troop.SIZE, also the number of element in Troop
+    troop_size = 8  # Cairo's Troop.SIZE, also the number of elements in Troop
     for i in range(25):
         partial_squad = build_partial_squad(i)
         tier = 1
@@ -350,7 +358,7 @@ async def test_find_first_free_troop_slot_in_squad(library_combat_tests):
 @pytest.mark.asyncio
 async def test_update_squad_in_realm(s06_combat):
     realm_id = (1, 0)
-    packed_empty_squad = PackedSquad(0, 0, 0, 0, 0, 0, 0)
+    packed_empty_squad = PackedSquad(0, 0)
     default_squad = build_default_squad()
     packed_default_squad = pack_squad(default_squad)
 

--- a/tests/settling_game/L06_Combat_tests.cairo
+++ b/tests/settling_game/L06_Combat_tests.cairo
@@ -1,6 +1,7 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
 from contracts.settling_game.L06_Combat import (
     run_combat_loop, attack, compute_min_roll_to_hit, hit_troop, hit_squad)
 from contracts.settling_game.utils.game_structs import Troop, Squad
@@ -9,14 +10,14 @@ from contracts.settling_game.utils.game_structs import Troop, Squad
 func test_run_combat_loop{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : HashBuiltin*}(
         attacker : Squad, defender : Squad, attack_type : felt) -> (
         attacker : Squad, defender : Squad, outcome : felt):
-    let (a, d, o) = run_combat_loop(attacker, defender, attack_type)
+    let (a, d, o) = run_combat_loop(Uint256(1, 0), Uint256(2, 0), attacker, defender, attack_type)
     return (a, d, o)
 end
 
 @view
 func test_attack{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : HashBuiltin*}(
         a : Squad, d : Squad, attack_type : felt) -> (d_after_attack : Squad):
-    let (d_after_attack) = attack(a, d, attack_type)
+    let (d_after_attack) = attack(Uint256(1, 0), Uint256(2, 0), a, d, attack_type)
     return (d_after_attack)
 end
 

--- a/tests/settling_game/game_structs.py
+++ b/tests/settling_game/game_structs.py
@@ -3,15 +3,15 @@ from enum import IntEnum
 from tests.shared import pack_values
 
 Cost = namedtuple('Cost', 'resource_count bits packed_ids packed_amounts')
-CostWithLords = namedtuple(
-    'Cost', 'resource_count bits packed_ids packed_amounts lords')
-Troop = namedtuple('Troop', 'type tier agility attack defense vitality wisdom')
+CostWithLords = namedtuple('Cost', 'resource_count bits packed_ids packed_amounts lords')
+Troop = namedtuple('Troop', 'id type tier agility attack defense vitality wisdom')
 Squad = namedtuple(
     'Squad',
     't1_1 t1_2 t1_3 t1_4 t1_5 t1_6 t1_7 t1_8 t1_9 t1_10 t1_11 t1_12 t1_13 t1_14 t1_15 t1_16 '
     + 't2_1 t2_2 t2_3 t2_4 t2_5 t2_6 t2_7 t2_8 t3_1',
 )
-PackedSquad = namedtuple('PackedSquad', 'p1 p2 p3 p4 p5 p6 p7')
+PackedSquad = namedtuple('PackedSquad', 'p1 p2')
+
 
 class TroopId(IntEnum):
     Watchman = 1
@@ -30,6 +30,7 @@ class TroopId(IntEnum):
     Mage = 14
     Arcanist = 15
     GrandMarshal = 16
+
 
 class ResourceIds(IntEnum):
     Wood = 1
@@ -55,6 +56,7 @@ class ResourceIds(IntEnum):
     Mithral = 21
     Dragonhide = 22
 
+
 class BuildingId(IntEnum):
     Fairgrounds = 1
     RoyalReserve = 2
@@ -76,6 +78,7 @@ class BuildingId(IntEnum):
     Fishmonger = 18
     Farms = 19
     Hamlet = 20
+
 
 BUILDING_COSTS = {
     BuildingId.Fairgrounds: CostWithLords(

--- a/tests/settling_game/library_combat_tests.cairo
+++ b/tests/settling_game/library_combat_tests.cairo
@@ -22,6 +22,18 @@ func test_compute_squad_stats(s : Squad) -> (stats : SquadStats):
 end
 
 @view
+func test_pack_troop{range_check_ptr}(t : Troop) -> (packed : felt):
+    let (p) = COMBAT.pack_troop(t)
+    return (p)
+end
+
+@view
+func test_unpack_troop{range_check_ptr}(packed : felt) -> (t : Troop):
+    let (t) = COMBAT.unpack_troop(packed)
+    return (t)
+end
+
+@view
 func test_pack_squad{range_check_ptr}(s : Squad) -> (p : PackedSquad):
     let (p) = COMBAT.pack_squad(s)
     return (p)
@@ -31,12 +43,6 @@ end
 func test_unpack_squad{range_check_ptr}(p : PackedSquad) -> (s : Squad):
     let (s : Squad) = COMBAT.unpack_squad(p)
     return (s)
-end
-
-@view
-func test_unpack_troop{range_check_ptr}(packed : felt) -> (t : Troop):
-    let (t) = COMBAT.unpack_troop(packed)
-    return (t)
 end
 
 @view
@@ -70,9 +76,9 @@ func test_find_first_free_troop_slot_in_squad(s : Squad, tier : felt) -> (free_s
 end
 
 @view
-func test_add_troops_to_squad{range_check_ptr}(s : Squad, troop_ids_len : felt, troop_ids : felt*) -> (
-    squad : Squad
-):
+func test_add_troops_to_squad{range_check_ptr}(
+    s : Squad, troop_ids_len : felt, troop_ids : felt*
+) -> (squad : Squad):
     let (s : Squad) = COMBAT.add_troops_to_squad(s, troop_ids_len, troop_ids)
     return (s)
 end


### PR DESCRIPTION
As discussed in #107, this PR does only with using troop ID and vitality when packing it into a `PackedSquad`, dramatically decreasing the storage slots needed from 7 to 2 felts.

To do this, the `Troop` struct now also contains an `id` member.

Most combat library tests pass - those that don't (`test_run_combat_loop`, `test_attack` and `test_update_squad_in_realm`) fail because of the "external" ownership check.