### PR TITLE
chore: fixing some Amarna alerts

### DIFF
--- a/contracts/settling_game/tokens/Lords_ERC20_Mintable.cairo
+++ b/contracts/settling_game/tokens/Lords_ERC20_Mintable.cairo
@@ -2,7 +2,6 @@
 # OpenZeppelin Cairo Contracts v0.1.0 (token/erc20/ERC20_Upgradeable.cairo)
 
 %lang starknet
-%builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256

--- a/contracts/settling_game/tokens/Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/Realms_ERC721_Mintable.cairo
@@ -6,7 +6,7 @@
 
 %lang starknet
 
-from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, BitwiseBuiltin
+from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
 from openzeppelin.token.erc721.library import (
@@ -41,7 +41,6 @@ from openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner
 
 from openzeppelin.upgrades.library import (
     Proxy_initializer,
-    Proxy_only_admin,
     Proxy_set_implementation,
 )
 

--- a/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
@@ -42,7 +42,6 @@ from openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner,
 
 from openzeppelin.upgrades.library import (
     Proxy_initializer,
-    Proxy_only_admin,
     Proxy_set_implementation,
 )
 


### PR DESCRIPTION
An example PR for #115.

Deals with [this](https://github.com/BibliothecaForAdventurers/realms-contracts/security/code-scanning/1752), [this](https://github.com/BibliothecaForAdventurers/realms-contracts/security/code-scanning/1751), and [this](https://github.com/BibliothecaForAdventurers/realms-contracts/security/code-scanning/1750) Amarna alerts. Also removes a `%builtins` directive as those are deprecated in newer Cairo versions.