### PR TITLE
Wall defence

### DIFF
--- a/contracts/settling_game/L04_Calculator.cairo
+++ b/contracts/settling_game/L04_Calculator.cairo
@@ -107,7 +107,7 @@ end
 @view
 func calculate_troop_population{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     token_id : Uint256
-) -> (happiness : felt):
+) -> (troop_population : felt):
     alloc_locals
 
     # SUM TOTAL TROOP POPULATION

--- a/contracts/settling_game/L06_Combat.cairo
+++ b/contracts/settling_game/L06_Combat.cairo
@@ -13,7 +13,11 @@ from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import get_block_timestamp, get_caller_address, get_tx_info
 from contracts.settling_game.interfaces.IERC1155 import IERC1155
-from contracts.settling_game.interfaces.imodules import IModuleController, IL02_Resources, IL04_Calculator
+from contracts.settling_game.interfaces.imodules import (
+    IModuleController,
+    IL02_Resources,
+    IL04_Calculator,
+)
 from contracts.settling_game.interfaces.realms_IERC721 import realms_IERC721
 from contracts.settling_game.interfaces.ixoroshiro import IXoroshiro
 from contracts.settling_game.library.library_combat import COMBAT
@@ -153,7 +157,6 @@ func upgrade{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 end
 
 # TODO: write documentation
-# TODO: take a Realm's wall into consideration when attacking a Realm
 
 ############
 # EXTERNAL #
@@ -319,8 +322,12 @@ func inflict_wall_defense{range_check_ptr, syscall_ptr : felt*, pedersen_ptr : H
     alloc_locals
 
     let (controller : felt) = MODULE_controller_address()
-    let (calculator_addr : felt) = IModuleController.get_module_address(controller, ModuleIds.L04_Calculator)
-    let (defending_population : felt) = IL04_Calculator.calculate_population(calculator_addr, defending_realm_id)
+    let (calculator_addr : felt) = IModuleController.get_module_address(
+        controller, ModuleIds.L04_Calculator
+    )
+    let (defending_population : felt) = IL04_Calculator.calculate_population(
+        calculator_addr, defending_realm_id
+    )
 
     let (q, _) = unsigned_div_rem(defending_population, POPULATION_PER_HIT_POINT)
     let (is_in_range) = is_le(q, MAX_WALL_DEFENSE_HIT_POINTS)

--- a/contracts/settling_game/interfaces/imodules.cairo
+++ b/contracts/settling_game/interfaces/imodules.cairo
@@ -105,11 +105,19 @@ end
 namespace IL04_Calculator:
     func calculate_epoch() -> (epoch : felt):
     end
-    func calculate_wonder_tax() -> (tax_percentage : felt):
-    end
     func calculate_happiness(token_id : Uint256) -> (happiness : felt):
     end
+    func calculate_troop_population(token_id : Uint256) -> (troop_population : felt):
+    end
+    func calculate_culture(token_id : Uint256) -> (culture : felt):
+    end
+    func calculate_population(token_id : Uint256) -> (population : felt):
+    end
+    func calculate_food(token_id : Uint256) -> (food : felt):
+    end
     func calculate_tribute() -> (tribute : felt):
+    end
+    func calculate_wonder_tax() -> (tax_percentage : felt):
     end
 end
 


### PR DESCRIPTION
This PR introduces a wall defense mechanism of a Realm. 

As a first round of an attack, the attacking squad receives damage from the defending Realm (the "wall"). The amount of hit points inflicted is based on the Realm population as in the range of 0 to 5 (inclusive). Can be easily tweak as necessary. There's no event emitted about this.

There's also some small fixes (var rename and broadening of `IL04_Calculator` interface), since I've been digging in those parts.