### PR TITLE
add missing functions for s_realms interface

### DIFF
--- a/contracts/settling_game/interfaces/s_realms_IERC721.cairo
+++ b/contracts/settling_game/interfaces/s_realms_IERC721.cairo
@@ -16,6 +16,12 @@ namespace s_realms_IERC721:
     func symbol() -> (symbol : felt):
     end
 
+    func tokenByIndex(index : Uint256) -> (tokenId : Uint256):
+    end
+
+    func tokenOfOwnerByIndex(owner : felt, index : Uint256) -> (tokenId : Uint256):
+    end
+
     func balanceOf(owner : felt) -> (balance : Uint256):
     end
 


### PR DESCRIPTION
I wanted to use the s_realms_ERC721 contract from another contracts but had to add `tokenByIndex` function in the interface. The PR adds this function with `tokenOfOwnerByIndex`