### PR TITLE
chore: cairo lint fix

### DIFF
--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -574,7 +574,6 @@ func buy_tokens_loop{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
     return (currency_sold)
 end
 
-
 ###############
 # SELL TOKENS #
 ###############
@@ -709,7 +708,6 @@ func get_royalty_for_price{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ran
 
     return (royalty_fee)
 end
-
 
 # input arguments are:
 # 1) exact amount of token to buy
@@ -867,7 +865,7 @@ end
 @view
 func get_all_buy_price{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     token_ids_len : felt, token_ids : Uint256*, token_amounts_len : felt, token_amounts : Uint256*
-) -> (prices_len: felt, prices : Uint256*):
+) -> (prices_len : felt, prices : Uint256*):
     alloc_locals
 
     # Loop
@@ -931,7 +929,7 @@ end
 @view
 func get_all_rates{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     token_ids_len : felt, token_ids : Uint256*, token_amounts_len : felt, token_amounts : Uint256*
-) -> (prices_len: felt, prices : Uint256*):
+) -> (prices_len : felt, prices : Uint256*):
     alloc_locals
 
     # Loop
@@ -1053,7 +1051,6 @@ func safeBatchTransferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ran
     ERC1155_safeBatchTransferFrom(_from, to, ids_len, ids, amounts_len, amounts)
     return ()
 end
-
 
 #########
 # ADMIN #

--- a/contracts/exchange/library.cairo
+++ b/contracts/exchange/library.cairo
@@ -59,7 +59,7 @@ namespace AMM:
         with_attr error_message("Price cannot be 0"):
             let (is_zero) = uint256_le(price, Uint256(0, 0))
             assert_not_equal(is_zero, 1)
-        end    
+        end
 
         # Rounding errors favour the contract
         return (price)

--- a/contracts/token/interfaces/IERC1155_Receiver.cairo
+++ b/contracts/token/interfaces/IERC1155_Receiver.cairo
@@ -7,16 +7,21 @@ from starkware.cairo.common.uint256 import Uint256
 
 @contract_interface
 namespace IERC1155_Receiver:
-
     func onERC1155Received(
-            operator : felt, from_ : felt, id : Uint256, amount : Uint256,
-            data_len : felt, data : felt*) -> (selector : felt):
+        operator : felt, from_ : felt, id : Uint256, amount : Uint256, data_len : felt, data : felt*
+    ) -> (selector : felt):
     end
 
     func onERC1155BatchReceived(
-            operator : felt, from_ : felt, ids_len : felt, ids : Uint256*, 
-            amounts_len : felt, amounts : Uint256*, data_len : felt, data : felt*)
-            -> (selector : felt):
+        operator : felt,
+        from_ : felt,
+        ids_len : felt,
+        ids : Uint256*,
+        amounts_len : felt,
+        amounts : Uint256*,
+        data_len : felt,
+        data : felt*,
+    ) -> (selector : felt):
     end
 
     func supportsInterface(interfaceId : felt) -> (success : felt):


### PR DESCRIPTION
Ran `cairo-format -i` on the files to fix linting.