### PR TITLE
refactor(settling): new module structure

### DIFF
--- a/contracts/settling_game/L02_Resources.cairo
+++ b/contracts/settling_game/L02_Resources.cairo
@@ -39,7 +39,7 @@ from contracts.settling_game.library.library_module import Module
 from contracts.settling_game.interfaces.IERC1155 import IERC1155
 from contracts.settling_game.interfaces.realms_IERC721 import realms_IERC721
 from contracts.settling_game.interfaces.imodules import (
-    IL01_Settling,
+    Settling,
     IL04_Calculator,
     IL03_Buildings,
 )
@@ -112,7 +112,7 @@ func claim_resources{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
     let (resources_address) = Module.get_external_contract_address(ExternalContractIds.Resources)
 
     # modules
-    let (settling_logic_address) = Module.get_module_address(ModuleIds.L01_Settling)
+    let (settling_logic_address) = Module.get_module_address(ModuleIds.Settling)
 
     # FETCH OWNER
     let (owner) = IERC721.ownerOf(s_realms_address, token_id)
@@ -146,8 +146,8 @@ func claim_resources{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_che
     end
 
     # SET VAULT TIME = REMAINDER - CURRENT_TIME
-    IL01_Settling.set_time_staked(settling_logic_address, token_id, remainder)
-    IL01_Settling.set_time_vault_staked(settling_logic_address, token_id, vault_remainder)
+    Settling.set_time_staked(settling_logic_address, token_id, remainder)
+    Settling.set_time_vault_staked(settling_logic_address, token_id, vault_remainder)
 
     # get current buildings on realm
     let (buildings_address) = Module.get_module_address(ModuleIds.L03_Buildings)
@@ -204,7 +204,7 @@ func pillage_resources{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_c
     let (realms_address) = Module.get_external_contract_address(ExternalContractIds.Realms)
     let (s_realms_address) = Module.get_external_contract_address(ExternalContractIds.S_Realms)
     let (resources_address) = Module.get_external_contract_address(ExternalContractIds.Resources)
-    let (settling_logic_address) = Module.get_module_address(ModuleIds.L01_Settling)
+    let (settling_logic_address) = Module.get_module_address(ModuleIds.Settling)
 
     # FETCH REALM DATA
     let (realms_data : RealmData) = realms_IERC721.fetch_realm_data(realms_address, token_id)
@@ -221,7 +221,7 @@ func pillage_resources{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_c
     end
 
     # SET VAULT TIME = REMAINDER - CURRENT_TIME
-    IL01_Settling.set_time_vault_staked(settling_logic_address, token_id, pillagable_remainder)
+    Settling.set_time_vault_staked(settling_logic_address, token_id, pillagable_remainder)
 
     # get current buildings on realm
     let (buildings_address) = Module.get_module_address(ModuleIds.L03_Buildings)
@@ -267,10 +267,10 @@ func days_accrued{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_
     alloc_locals
 
     let (block_timestamp) = get_block_timestamp()
-    let (settling_logic_address) = Module.get_module_address(ModuleIds.L01_Settling)
+    let (settling_logic_address) = Module.get_module_address(ModuleIds.Settling)
 
     # GET DAYS ACCRUED
-    let (last_update) = IL01_Settling.get_time_staked(settling_logic_address, token_id)
+    let (last_update) = Settling.get_time_staked(settling_logic_address, token_id)
     let (days_accrued, seconds_left_over) = unsigned_div_rem(block_timestamp - last_update, DAY)
 
     let (is_less_than_max) = is_le(days_accrued, MAX_DAYS_ACCURED + 1)
@@ -293,10 +293,10 @@ func vault_days_accrued{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_
     alloc_locals
 
     let (block_timestamp) = get_block_timestamp()
-    let (settling_logic_address) = Module.get_module_address(ModuleIds.L01_Settling)
+    let (settling_logic_address) = Module.get_module_address(ModuleIds.Settling)
 
     # GET DAYS ACCRUED
-    let (last_update) = IL01_Settling.get_time_vault_staked(settling_logic_address, token_id)
+    let (last_update) = Settling.get_time_vault_staked(settling_logic_address, token_id)
     let (days_accrued, seconds_left_over) = unsigned_div_rem(block_timestamp - last_update, DAY)
 
     return (days_accrued, seconds_left_over)

--- a/contracts/settling_game/L04_Calculator.cairo
+++ b/contracts/settling_game/L04_Calculator.cairo
@@ -29,7 +29,7 @@ from contracts.settling_game.utils.game_structs import (
 from contracts.settling_game.utils.constants import VAULT_LENGTH_SECONDS, BASE_LORDS_PER_DAY
 from contracts.settling_game.interfaces.imodules import (
     IModuleController,
-    IL01_Settling,
+    Settling,
     IL03_Buildings,
     IL06_Combat,
 )
@@ -176,10 +176,10 @@ func calculate_wonder_tax{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, rang
     # CALCULATE WONDER TAX
     let (controller) = Module.controller_address()
     let (settle_state_address) = IModuleController.get_module_address(
-        controller, ModuleIds.L01_Settling
+        controller, ModuleIds.Settling
     )
 
-    let (realms_settled) = IL01_Settling.get_total_realms_settled(settle_state_address)
+    let (realms_settled) = Settling.get_total_realms_settled(settle_state_address)
 
     let (less_than_tenth_settled) = is_nn_le(realms_settled, 1600)
 

--- a/contracts/settling_game/ModuleController.cairo
+++ b/contracts/settling_game/ModuleController.cairo
@@ -92,10 +92,10 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     # write patterns known at deployment. E.g., 1->2, 1->3, 5->6.
 
     # settling to wonders logic
-    can_write_to.write(ModuleIds.L01_Settling, ModuleIds.L05_Wonders, TRUE)
+    can_write_to.write(ModuleIds.Settling, ModuleIds.L05_Wonders, TRUE)
 
     # resources logic to settling state
-    can_write_to.write(ModuleIds.L02_Resources, ModuleIds.L01_Settling, TRUE)
+    can_write_to.write(ModuleIds.L02_Resources, ModuleIds.Settling, TRUE)
 
     # resources logic to wonders state
     can_write_to.write(ModuleIds.L02_Resources, ModuleIds.L05_Wonders, TRUE)
@@ -104,7 +104,7 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     can_write_to.write(ModuleIds.L06_Combat, ModuleIds.L02_Resources, TRUE)
 
     # # combat can write to settling
-    can_write_to.write(ModuleIds.L06_Combat, ModuleIds.L01_Settling, TRUE)
+    can_write_to.write(ModuleIds.L06_Combat, ModuleIds.Settling, TRUE)
 
     # # crypts logic to resources
     # can_write_to.write(ModuleIds.L07_Crypts, ModuleIds.L08_Crypts_Resources, TRUE)
@@ -171,7 +171,7 @@ end
 func set_initial_module_addresses{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }(
-    module_01_addr : felt,
+    settling_module_addr : felt,
     module_02_addr : felt,
     module_03_addr : felt,
     module_04_addr : felt,
@@ -181,8 +181,8 @@ func set_initial_module_addresses{
     only_arbiter()
 
     # Settling Logic
-    address_of_module_id.write(ModuleIds.L01_Settling, module_01_addr)
-    module_id_of_address.write(module_01_addr, ModuleIds.L01_Settling)
+    address_of_module_id.write(ModuleIds.Settling, settling_module_addr)
+    module_id_of_address.write(settling_module_addr, ModuleIds.Settling)
 
     # Resources Logic
     address_of_module_id.write(ModuleIds.L02_Resources, module_02_addr)

--- a/contracts/settling_game/README.md
+++ b/contracts/settling_game/README.md
@@ -15,7 +15,7 @@ A modular game engine architecture for the StarkNet L2 roll-up - Forked & heavil
 
 | Module          | Function                             | Current Status |
 | --------------- | ------------------------------------ | -------------- |
-| [Settling](./L01_Settling.cairo)        | Manages Settling (staking functions) | In review      |
+| [Settling](./modules/settling/Settling.cairo)        | Manages Settling (staking functions) | In review      |
 | [Resources](./L02_Resources.cairo)       | Resource management                  | In review      |
 | [Buildings](./L03_Buildings.cairo)       | Buildings management                 | In review      |
 | [Calculator](./L04_Calculator.cairo)      | Calculator management                | In review      |
@@ -37,4 +37,3 @@ A modular game engine architecture for the StarkNet L2 roll-up - Forked & heavil
 - [] Guilds
 
 </details>
-

--- a/contracts/settling_game/interfaces/imodules.cairo
+++ b/contracts/settling_game/interfaces/imodules.cairo
@@ -66,7 +66,7 @@ namespace IModuleController:
 end
 
 @contract_interface
-namespace IL01_Settling:
+namespace Settling:
     func set_time_staked(token_id : Uint256, time_left : felt):
     end
     func set_time_vault_staked(token_id : Uint256, time_left : felt):

--- a/contracts/settling_game/modules/settling/Settling.cairo
+++ b/contracts/settling_game/modules/settling/Settling.cairo
@@ -1,5 +1,5 @@
 # -----------------------------------
-# ____Module.L01___SETTLING_LOGIC
+#   Module.SETTLING_LOGIC
 #   Core Settling Game logic including setting up the world
 #   and staking/unstaking a realm.
 #

--- a/contracts/settling_game/utils/game_structs.cairo
+++ b/contracts/settling_game/utils/game_structs.cairo
@@ -152,7 +152,7 @@ namespace ArmyCap:
 end
 
 namespace ModuleIds:
-    const L01_Settling = 1
+    const Settling = 1
     const L02_Resources = 2
     const L03_Buildings = 3
     const L04_Calculator = 4

--- a/realms_cli/deploy/game_contracts.py
+++ b/realms_cli/deploy/game_contracts.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from realms_cli.deployer import logged_deploy
 from realms_cli.caller_invoker import wrapped_send, declare
-from realms_cli.shared import str_to_felt
 from realms_cli.config import Config, strhex_as_strfelt, safe_load_deployment
 import time
 
@@ -9,7 +8,7 @@ Contracts = namedtuple('Contracts', 'alias contract_name')
 
 # token tuples
 MODULE_CONTRACT_IMPLEMENTATIONS = [
-    Contracts("L01_Settling", "L01_Settling"),
+    Contracts("Settling", "Settling"),
     Contracts("L02_Resources", "L02_Resources"),
     Contracts("L03_Buildings", "L03_Buildings"),
     Contracts("L04_Calculator", "L04_Calculator"),

--- a/realms_cli/deploy/init_game.py
+++ b/realms_cli/deploy/init_game.py
@@ -14,7 +14,7 @@ def run(nre):
         contract_alias="arbiter",
         function="batch_set_controller_addresses",
         arguments=[
-            strhex_as_strfelt(config.L01_SETTLING_PROXY_ADDRESS),
+            strhex_as_strfelt(config.SETTLING_PROXY_ADDRESS),
             strhex_as_strfelt(config.L02_RESOURCES_PROXY_ADDRESS),
             strhex_as_strfelt(config.L03_BUILDINGS_PROXY_ADDRESS),
             strhex_as_strfelt(config.L04_CALCULATOR_PROXY_ADDRESS),
@@ -23,7 +23,7 @@ def run(nre):
         ],
     )
 
-    # --------- L01_SETTLING_PROXY_ADDRESS Approvals ------- #
+    # --------- SETTLING_PROXY_ADDRESS Approvals ------- #
 
     wrapped_send(
         network=config.nile_network,
@@ -31,7 +31,7 @@ def run(nre):
         contract_alias="proxy_s_realms",
         function="Set_module_access",
         arguments=[
-            strhex_as_strfelt(config.L01_SETTLING_PROXY_ADDRESS),
+            strhex_as_strfelt(config.SETTLING_PROXY_ADDRESS),
         ]
     )
 
@@ -41,7 +41,7 @@ def run(nre):
         contract_alias="proxy_realms",
         function="setApprovalForAll",
         arguments=[
-            strhex_as_strfelt(config.L01_SETTLING_PROXY_ADDRESS),
+            strhex_as_strfelt(config.SETTLING_PROXY_ADDRESS),
             "1",
         ]
     )
@@ -52,7 +52,7 @@ def run(nre):
         contract_alias="proxy_lords",
         function="approve",
         arguments=[
-            strhex_as_strfelt(config.L01_SETTLING_PROXY_ADDRESS),
+            strhex_as_strfelt(config.SETTLING_PROXY_ADDRESS),
             str(config.INITIAL_LORDS_SUPPLY), 0
         ]
     )

--- a/realms_cli/realms_cli/config.py
+++ b/realms_cli/realms_cli/config.py
@@ -80,8 +80,8 @@ class Config:
         # self.CRYPTS_PROXY_ADDRESS, _ = safe_load_deployment("proxy_crypts", self.nile_network)
         # self.S_CRYPTS_PROXY_ADDRESS, _ = safe_load_deployment("proxy_s_crypts", self.nile_network)
 
-        self.L01_SETTLING_ADDRESS, _ = safe_load_deployment(
-            "L01_Settling", self.nile_network)
+        self.SETTLING_ADDRESS, _ = safe_load_deployment(
+            "Settling", self.nile_network)
         self.L02_RESOURCES_ADDRESS, _ = safe_load_deployment(
             "L02_Resources", self.nile_network)
         self.L03_BUILDINGS_ADDRESS, _ = safe_load_deployment(
@@ -94,8 +94,8 @@ class Config:
             "L06_Combat", self.nile_network)
         # self.L07_CRYPTS_ADDRESS, _ = safe_load_deployment("L07_Crypts", self.nile_network)
 
-        self.L01_SETTLING_PROXY_ADDRESS, _ = safe_load_deployment(
-            "proxy_L01_Settling", self.nile_network)
+        self.SETTLING_PROXY_ADDRESS, _ = safe_load_deployment(
+            "proxy_Settling", self.nile_network)
         self.L02_RESOURCES_PROXY_ADDRESS, _ = safe_load_deployment(
             "proxy_L02_Resources", self.nile_network)
         self.L03_BUILDINGS_PROXY_ADDRESS, _ = safe_load_deployment(

--- a/realms_cli/realms_cli/player/settle.py
+++ b/realms_cli/realms_cli/player/settle.py
@@ -48,7 +48,7 @@ def approve_realm(network):
         contract_alias="proxy_realms",
         function="setApprovalForAll",
         arguments=[
-            int(config.L01_SETTLING_PROXY_ADDRESS, 16),  # uint1
+            int(config.SETTLING_PROXY_ADDRESS, 16),  # uint1
             "1",               # true
         ],
     )
@@ -72,7 +72,7 @@ def settle(realm_token_id, network):
     wrapped_send(
         network=config.nile_network,
         signer_alias=config.USER_ALIAS,
-        contract_alias="proxy_L01_Settling",
+        contract_alias="proxy_Settling",
         function="settle",
         arguments=calldata
     )
@@ -96,7 +96,7 @@ def unsettle(realm_token_id, network):
     wrapped_send(
         network=config.nile_network,
         signer_alias=config.USER_ALIAS,
-        contract_alias="proxy_L01_Settling",
+        contract_alias="proxy_Settling",
         function="unsettle",
         arguments=calldata,
     )

--- a/tasks/settling/game_actions/mint_realm_stake.ts
+++ b/tasks/settling/game_actions/mint_realm_stake.ts
@@ -7,7 +7,7 @@ async function main() {
     // const arbiter = getDeployedAddressInt('Arbiter');
     const ownerAccount = getOwnerAccountInt()
     // Collect params
-    // const L01_Settling = getDeployedAddressInt("L01_Settling"); // module id 1
+    // const Settling = getDeployedAddressInt("Settling"); // module id 1
     const Realms_ERC721_Mintable = getDeployedAddressInt("Realms_ERC721_Mintable"); // module id 1
 
     const realm: Uint256 = bnToUint256("3")
@@ -22,7 +22,7 @@ async function main() {
 
     // const res = await getSigner().execute(
     //     {
-    //         contractAddress: L01_Settling,
+    //         contractAddress: Settling,
     //         entrypoint: "settle",
     //         calldata: [realm.low.toString(), realm.high.toString()]
     //     }

--- a/tasks/settling/modules/01_deploy_settling.ts
+++ b/tasks/settling/modules/01_deploy_settling.ts
@@ -2,9 +2,9 @@
 import { deployContract, getOwnerAccountInt, setupDeploymentDir, getDeployedAddressInt, getSigner, getAccountContract } from '../../helpers'
 
 async function main() {
-    const proxyLogicContractName = 'PROXY_L01_Settling'
-    const logicContractName = 'L01_Settling'
-    const stateContractName = 'S01_Settling'
+    const proxyLogicContractName = 'PROXY_Settling'
+    const logicContractName = 'Settling'
+    const stateContractName = 'Settling'
 
     setupDeploymentDir()
     const ownerAccount = getOwnerAccountInt()
@@ -12,7 +12,7 @@ async function main() {
     // Collect params
     const moduleControllerAddress = getDeployedAddressInt("ModuleController");
 
-    // Magically deploy + write all files and stuff 
+    // Magically deploy + write all files and stuff
     // Implementation
     // await deployContract(logicContractName, logicContractName, [])
 


### PR DESCRIPTION
Applies #157 to the Settling module.

There's still some traces of "L01" left, but it's in pieces of code which I believe are stale, not used anymore (e.g. .ts files in [`tasks/settling/modules/`](https://github.com/BibliothecaForAdventurers/realms-contracts/tree/main/tasks/settling/modules)).