### PR TITLE
dev: adding multiplier argument when calculating cost tokens

### DIFF
--- a/contracts/settling_game/L06_Combat.cairo
+++ b/contracts/settling_game/L06_Combat.cairo
@@ -47,7 +47,7 @@ from contracts.settling_game.utils.game_structs import (
     Cost,
     ExternalContractIds,
 )
-from contracts.settling_game.utils.general import unpack_data, transform_costs_to_token_ids_values
+from contracts.settling_game.utils.general import unpack_data, transform_costs_to_tokens
 from contracts.settling_game.library.library_module import Module
 
 from contracts.settling_game.utils.constants import DAY
@@ -168,10 +168,8 @@ func build_squad_from_troops_in_realm{
     load_troop_costs(troop_ids_len, troop_ids, troop_costs)
 
     # transform costs into tokens
-    let (token_ids : Uint256*) = alloc()
-    let (token_values : Uint256*) = alloc()
-    let (token_len : felt) = transform_costs_to_token_ids_values(
-        troop_ids_len, troop_costs, token_ids, token_values
+    let (token_len : felt, token_ids : Uint256*, token_values : Uint256*) = transform_costs_to_tokens(
+        troop_ids_len, troop_costs, 1
     )
 
     # pay for the squad

--- a/contracts/settling_game/modules/food/Food.cairo
+++ b/contracts/settling_game/modules/food/Food.cairo
@@ -29,7 +29,7 @@ from contracts.settling_game.utils.constants import (
     BASE_FOOD_PRODUCTION,
     STORE_HOUSE_SIZE,
 )
-from contracts.settling_game.utils.general import calculate_cost
+from contracts.settling_game.utils.general import transform_costs_to_tokens
 from contracts.settling_game.utils.game_structs import (
     RealmData,
     ModuleIds,
@@ -151,15 +151,15 @@ func create{
         fishing_villages.write(token_id, packed)
     end
 
-    let (buildings_address) = Module.get_module_address(ModuleIds.L03_Buildings)
-
     # Costs
+    let (buildings_address) = Module.get_module_address(ModuleIds.L03_Buildings)
     let (cost, _) = IL03_Buildings.get_building_cost(buildings_address, food_building_id)
-    let (resources_address) = Module.get_external_contract_address(ExternalContractIds.Resources)
-
-    let (token_len, token_ids, token_values) = calculate_cost(cost)
+    let (costs : Cost*) = alloc()
+    assert [costs] = cost
+    let (token_len, token_ids, token_values) = transform_costs_to_tokens(1, costs, qty)
 
     # BURN RESOURCES
+    let (resources_address) = Module.get_external_contract_address(ExternalContractIds.Resources)
     IERC1155.burnBatch(resources_address, owner, token_len, token_ids, token_len, token_values)
 
     return ()

--- a/contracts/settling_game/utils/general.cairo
+++ b/contracts/settling_game/utils/general.cairo
@@ -68,23 +68,29 @@ func unpack_data{
     return (score=result)
 end
 
-# function takes an array of Cost structs and restructures it into two arrays,
+# calculates cost and returns
+# TODO: docstring
+
+# @notice function takes an array of Cost structs and restructures it into two arrays,
 # one holding the resource IDs of tokens and the other the amounts of these tokens
 # which can be directly passed into a IERC1155.burnBatch call
-# the return value of this function is the length of the token arrays, i.e. the
-# count of unique tokens
-# the token_ids and token_values argument have to be `alloc()`ed in the calling
-# scope:
-#
-# let (token_ids : Uint256*) = alloc()
-# let (token_values : Uint256*) = alloc()
-# let (token_len : felt) = transform_costs_to_token_ids_values(costs_len, costs, toekn_ids, token_values)
-func transform_costs_to_token_ids_values{
-    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*, bitwise_ptr : BitwiseBuiltin*
-}(costs_len : felt, costs : Cost*, token_ids : Uint256*, token_values : Uint256*) -> (
-    tokens : felt
+# the thrid argument to this function is a quantity multiplier that is applied
+# to every amount value in the token_values array; useful when "buying" multiples
+# of the same stuff
+# @param costs_len: length of the costs array
+# @param costs: array of costs
+# @param qty: quantity multiplier for value amounts
+# @return token_len: length of the two return arrays (token_ids and token_values, their length is identical),
+#                    in other words, the count of unique tokens
+# @return token_ids: an array of resource IDs
+# @return token_values: an array of amounts of resources
+func transform_costs_to_tokens{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, bitwise_ptr : BitwiseBuiltin*
+}(costs_len : felt, costs : Cost*, qty : felt) -> (
+    token_len : felt, token_ids : Uint256*, token_values : Uint256*
 ):
     alloc_locals
+
     # destructure the costs array to two arrays, one
     # holding the IDs of resources and the other one values of resources
     # that are required to build the Troops
@@ -99,9 +105,14 @@ func transform_costs_to_token_ids_values{
     let (d_len : felt, d : DictAccess*) = sum_values_by_key(
         resource_len, resource_ids, resource_values
     )
-    convert_cost_dict_to_tokens_and_values(d_len, d, token_ids, token_values)
 
-    return (d_len)
+    # populate the toke IDs and token values arrays with correct values
+    # from the dictionary
+    let (token_ids : Uint256*) = alloc()
+    let (token_values : Uint256*) = alloc()
+    convert_cost_dict_to_tokens_and_values(d_len, d, qty, token_ids, token_values)
+
+    return (d_len, token_ids, token_values)
 end
 
 # function takes an array of Cost structs (which hold packed values of
@@ -159,8 +170,13 @@ end
 # function takes a dictionary where the keys are (ERC1155) token IDs and
 # values are the amounts to be bought and populates the passed in `token_ids`
 # and `token_values` arrays with Uint256 elements
+# all values are multiplier by `value_multiplier`
 func convert_cost_dict_to_tokens_and_values{range_check_ptr}(
-    len : felt, d : DictAccess*, token_ids : Uint256*, token_values : Uint256*
+    len : felt,
+    d : DictAccess*,
+    value_multiplier : felt,
+    token_ids : Uint256*,
+    token_values : Uint256*,
 ):
     alloc_locals
 
@@ -177,10 +193,14 @@ func convert_cost_dict_to_tokens_and_values{range_check_ptr}(
         assert_le(current_entry.new_value, MAX_UINT_PART)
     end
     assert [token_ids] = Uint256(low=current_entry.key, high=0)
-    assert [token_values] = Uint256(low=current_entry.new_value * 10 ** 18, high=0)
+    assert [token_values] = Uint256(low=current_entry.new_value * 10 ** 18 * value_multiplier, high=0)
 
     return convert_cost_dict_to_tokens_and_values(
-        len - 1, d + DictAccess.SIZE, token_ids + Uint256.SIZE, token_values + Uint256.SIZE
+        len - 1,
+        d + DictAccess.SIZE,
+        value_multiplier,
+        token_ids + Uint256.SIZE,
+        token_values + Uint256.SIZE,
     )
 end
 
@@ -230,19 +250,4 @@ func sum_values_by_key_loop{range_check_ptr}(
     dict_write{dict_ptr=dict}(key=[keys], new_value=updated)
 
     return sum_values_by_key_loop(dict, len - 1, keys + 1, values + 1)
-end
-
-# calculates cost and returns
-func calculate_cost{
-    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, bitwise_ptr : BitwiseBuiltin*
-}(cost : Cost) -> (token_len : felt, token_ids : Uint256*, token_values : Uint256*):
-    alloc_locals
-
-    let (costs : Cost*) = alloc()
-    assert [costs] = cost
-    let (token_ids : Uint256*) = alloc()
-    let (token_values : Uint256*) = alloc()
-
-    let (token_len) = transform_costs_to_token_ids_values(1, costs, token_ids, token_values)
-    return (token_len, token_ids, token_values)
 end

--- a/tests/pytest/settling_game/06_combat_test.py
+++ b/tests/pytest/settling_game/06_combat_test.py
@@ -182,19 +182,25 @@ async def test_get_set_troop_cost(l06_combat):
 # of load_resource_ids_and_values_from_cost, convert_cost_dict_to_tokens_and_values
 # and sum_values_by_key in general.cairo file, as it calls them all
 @pytest.mark.asyncio
-async def test_transform_costs_to_token_ids_values(utils_general_tests):
-    costs = [TROOP_COSTS[TroopId.Watchman], TROOP_COSTS[TroopId.Guard]]
-    tx = await utils_general_tests.test_transform_costs_to_token_ids_values(costs).invoke()
+async def test_transform_costs_to_tokens(utils_general_tests):
+    costs = [TROOP_COSTS[TroopId.Crossbow], TROOP_COSTS[TroopId.Ballista]]
+    tx = await utils_general_tests.test_transform_costs_to_tokens(costs, 1).invoke()
 
-    expected_ids = [
-        ResourceIds.Wood,
-        ResourceIds.Stone,
-        ResourceIds.Copper,
-    ]
-    expected_values = [6, 9, 15]
+    expected_ids = [ResourceIds.Stone, ResourceIds.Coal, ResourceIds.Gold, ResourceIds.Mithral, ResourceIds.Dragonhide]
+    expected_values = [28, 8, 5, 1, 1]
 
     assert tx.result.ids == [utils_general_tests.Uint256(low=v, high=0) for v in expected_ids]
-    assert tx.result.values == [utils_general_tests.Uint256(low=v, high=0) for v in expected_values]
+    assert tx.result.values == [utils_general_tests.Uint256(low=v * 10**18, high=0) for v in expected_values]
+
+    # buying 20 Pikemen
+    costs = [TROOP_COSTS[TroopId.Pikeman]]
+    tx = await utils_general_tests.test_transform_costs_to_tokens(costs, 20).invoke()
+
+    expected_ids = [ResourceIds.Diamonds]
+    expected_values = [20]
+
+    assert tx.result.ids == [utils_general_tests.Uint256(low=v, high=0) for v in expected_ids]
+    assert tx.result.values == [utils_general_tests.Uint256(low=v * 10**18, high=0) for v in expected_values]
 
 
 @pytest.mark.asyncio

--- a/tests/pytest/settling_game/utils/general_tests.cairo
+++ b/tests/pytest/settling_game/utils/general_tests.cairo
@@ -9,7 +9,7 @@ from contracts.settling_game.utils.game_structs import Cost
 
 from contracts.settling_game.utils.general import (
     unpack_data,
-    transform_costs_to_token_ids_values,
+    transform_costs_to_tokens,
     load_resource_ids_and_values_from_costs,
     sum_values_by_key,
 )
@@ -23,16 +23,12 @@ func test_unpack_data{
 end
 
 @view
-func test_transform_costs_to_token_ids_values{
+func test_transform_costs_to_tokens{
     syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*, bitwise_ptr : BitwiseBuiltin*
-}(costs_len : felt, costs : Cost*) -> (
+}(costs_len : felt, costs : Cost*, qty : felt) -> (
     ids_len : felt, ids : Uint256*, values_len : felt, values : Uint256*
 ):
-    alloc_locals
-
-    let (ids : Uint256*) = alloc()
-    let (values : Uint256*) = alloc()
-    let (len : felt) = transform_costs_to_token_ids_values(costs_len, costs, ids, values)
+    let (len : felt, ids : Uint256*, values : Uint256*) = transform_costs_to_tokens(costs_len, costs, qty)
 
     return (len, ids, len, values)
 end


### PR DESCRIPTION
This PR adds support to specify a quantity multiplier to an internal function that transforms `Cost` structs to token values. In non-convoluted speak, this means it's now easy to "buy 20 things" - just need the `Cost` struct of a thing and set `qty` to 20.

I've merged `calculate_cost` and `transform_costs_to_token_ids_values` to a single function called `transform_costs_to_tokens` and updated its use in combat and food modules.