### PR TITLE
feat: Add token module permissions

### DIFF
--- a/contracts/settling_game/ModuleController.cairo
+++ b/contracts/settling_game/ModuleController.cairo
@@ -92,10 +92,10 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     # write patterns known at deployment. E.g., 1->2, 1->3, 5->6.
 
     # settling to wonders logic
-    can_write_to.write(ModuleIds.L01_Settling, ModuleIds.L05_Wonders, TRUE)
+    can_write_to.write(ModuleIds.Settling, ModuleIds.L05_Wonders, TRUE)
 
     # resources logic to settling state
-    can_write_to.write(ModuleIds.L02_Resources, ModuleIds.L01_Settling, TRUE)
+    can_write_to.write(ModuleIds.L02_Resources, ModuleIds.Settling, TRUE)
 
     # resources logic to wonders state
     can_write_to.write(ModuleIds.L02_Resources, ModuleIds.L05_Wonders, TRUE)
@@ -104,10 +104,10 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     can_write_to.write(ModuleIds.L06_Combat, ModuleIds.L02_Resources, TRUE)
 
     # # combat can write to settling
-    can_write_to.write(ModuleIds.L06_Combat, ModuleIds.L01_Settling, TRUE)
+    can_write_to.write(ModuleIds.L06_Combat, ModuleIds.Settling, TRUE)
 
     # settling can write to s realms tokens
-    can_write_to.write(ModuleIds.L01_Settling, ModuleIds.S_Realms_Token, TRUE)
+    can_write_to.write(ModuleIds.Settling, ModuleIds.S_Realms_Token, TRUE)
 
     # resources can write to resources token
     can_write_to.write(ModuleIds.L02_Resources, ModuleIds.Resources_Token, TRUE)
@@ -189,7 +189,7 @@ end
 func set_initial_module_addresses{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }(
-    module_01_addr : felt,
+    settling_module_addr : felt,
     module_02_addr : felt,
     module_03_addr : felt,
     module_04_addr : felt,
@@ -199,8 +199,8 @@ func set_initial_module_addresses{
     only_arbiter()
 
     # Settling Logic
-    address_of_module_id.write(ModuleIds.L01_Settling, module_01_addr)
-    module_id_of_address.write(module_01_addr, ModuleIds.L01_Settling)
+    address_of_module_id.write(ModuleIds.Settling, settling_module_addr)
+    module_id_of_address.write(settling_module_addr, ModuleIds.Settling)
 
     # Resources Logic
     address_of_module_id.write(ModuleIds.L02_Resources, module_02_addr)

--- a/contracts/settling_game/ModuleController.cairo
+++ b/contracts/settling_game/ModuleController.cairo
@@ -92,10 +92,10 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     # write patterns known at deployment. E.g., 1->2, 1->3, 5->6.
 
     # settling to wonders logic
-    can_write_to.write(ModuleIds.Settling, ModuleIds.L05_Wonders, TRUE)
+    can_write_to.write(ModuleIds.L01_Settling, ModuleIds.L05_Wonders, TRUE)
 
     # resources logic to settling state
-    can_write_to.write(ModuleIds.L02_Resources, ModuleIds.Settling, TRUE)
+    can_write_to.write(ModuleIds.L02_Resources, ModuleIds.L01_Settling, TRUE)
 
     # resources logic to wonders state
     can_write_to.write(ModuleIds.L02_Resources, ModuleIds.L05_Wonders, TRUE)
@@ -104,7 +104,25 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     can_write_to.write(ModuleIds.L06_Combat, ModuleIds.L02_Resources, TRUE)
 
     # # combat can write to settling
-    can_write_to.write(ModuleIds.L06_Combat, ModuleIds.Settling, TRUE)
+    can_write_to.write(ModuleIds.L06_Combat, ModuleIds.L01_Settling, TRUE)
+
+    # settling can write to s realms tokens
+    can_write_to.write(ModuleIds.L01_Settling, ModuleIds.S_Realms_Token, TRUE)
+
+    # resources can write to resources token
+    can_write_to.write(ModuleIds.L02_Resources, ModuleIds.Resources_Token, TRUE)
+
+    # buildings can write to resources token
+    can_write_to.write(ModuleIds.L03_Buildings, ModuleIds.Resources_Token, TRUE)
+
+    # combat can write to resources token
+    can_write_to.write(ModuleIds.L06_Combat, ModuleIds.Resources_Token, TRUE)
+
+    # crypts can write to crypts token
+    can_write_to.write(ModuleIds.L07_Crypts, ModuleIds.S_Crypts_Token, TRUE)
+
+    # crypts resources can write to resources token
+    can_write_to.write(ModuleIds.L08_Crypts_Resources, ModuleIds.Resources_Token, TRUE)
 
     # # crypts logic to resources
     # can_write_to.write(ModuleIds.L07_Crypts, ModuleIds.L08_Crypts_Resources, TRUE)
@@ -171,7 +189,7 @@ end
 func set_initial_module_addresses{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }(
-    settling_module_addr : felt,
+    module_01_addr : felt,
     module_02_addr : felt,
     module_03_addr : felt,
     module_04_addr : felt,
@@ -181,8 +199,8 @@ func set_initial_module_addresses{
     only_arbiter()
 
     # Settling Logic
-    address_of_module_id.write(ModuleIds.Settling, settling_module_addr)
-    module_id_of_address.write(settling_module_addr, ModuleIds.Settling)
+    address_of_module_id.write(ModuleIds.L01_Settling, module_01_addr)
+    module_id_of_address.write(module_01_addr, ModuleIds.L01_Settling)
 
     # Resources Logic
     address_of_module_id.write(ModuleIds.L02_Resources, module_02_addr)

--- a/contracts/settling_game/tokens/Resources_ERC1155_Mintable_Burnable.cairo
+++ b/contracts/settling_game/tokens/Resources_ERC1155_Mintable_Burnable.cairo
@@ -15,6 +15,8 @@ from openzeppelin.upgrades.library import Proxy
 
 from openzeppelin.introspection.ERC165 import ERC165
 
+from contracts.settling_game.library.library_module import Module
+
 # move to OZ lib once live
 from contracts.token.library import ERC1155
 
@@ -119,8 +121,7 @@ end
 func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     to : felt, id : Uint256, amount : Uint256, data_len : felt, data : felt*
 ):
-    # TODO: Module based approach
-    # check_can_action()
+    Module.only_approved()
     let (caller) = get_caller_address()
     with_attr error_message("ERC1155: called from zero address"):
         assert_not_zero(caller)
@@ -139,8 +140,7 @@ func mintBatch{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     data_len : felt,
     data : felt*,
 ):
-    # TODO: Module based approach
-    # check_can_action()
+    Module.only_approved()
     let (caller) = get_caller_address()
     with_attr error_message("ERC1155: called from zero address"):
         assert_not_zero(caller)
@@ -166,62 +166,11 @@ end
 func burnBatch{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     from_ : felt, ids_len : felt, ids : Uint256*, amounts_len : felt, amounts : Uint256*
 ):
-    # TODO: Module based approach
-    # ERC1155.assert_owner_or_approved(owner=from_)
+    Module.only_approved()
     let (caller) = get_caller_address()
     with_attr error_message("ERC1155: called from zero address"):
         assert_not_zero(caller)
     end
     ERC1155._burn_batch(from_, ids_len, ids, amounts_len, amounts)
-    return ()
-end
-#
-# Bibliotheca added methods
-#
-
-@storage_var
-func Module_access() -> (address : felt):
-end
-
-@external
-func Set_module_access{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-    address : felt
-):
-    Ownable.assert_only_owner()
-    Module_access.write(address)
-    return ()
-end
-
-func check_caller{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
-    value : felt
-):
-    let (address) = Module_access.read()
-    let (caller) = get_caller_address()
-
-    if address == caller:
-        return (1)
-    end
-
-    return (0)
-end
-
-func check_owner{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
-    value : felt
-):
-    let (caller) = get_caller_address()
-    let (owner) = Ownable.owner()
-
-    if caller == owner:
-        return (1)
-    end
-
-    return (0)
-end
-
-func check_can_action{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
-    let (caller) = check_caller()
-    let (owner) = check_owner()
-
-    assert_not_zero(owner + caller)
     return ()
 end

--- a/contracts/settling_game/tokens/S_Crypts_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Crypts_ERC721_Mintable.cairo
@@ -17,6 +17,8 @@ from openzeppelin.upgrades.library import Proxy
 from contracts.settling_game.utils.general import unpack_data
 from contracts.settling_game.utils.game_structs import RealmData
 
+from contracts.settling_game.library.library_module import Module
+
 #
 # Initializer
 #
@@ -175,14 +177,14 @@ end
 func mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, tokenId : Uint256
 ):
-    Ownable.assert_only_owner()
+    Module.only_approved()
     ERC721_Enumerable._mint(to, tokenId)
     return ()
 end
 
 @external
 func burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(tokenId : Uint256):
-    ERC721.assert_only_token_owner(tokenId)
+    Module.only_approved()
     ERC721_Enumerable._burn(tokenId)
     return ()
 end
@@ -207,58 +209,5 @@ end
 @external
 func renounceOwnership{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     Ownable.renounce_ownership()
-    return ()
-end
-
-#
-# Bibliotheca added methods
-#
-
-@storage_var
-func Module_access() -> (address : felt):
-end
-
-@external
-func Set_module_access{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-    address : felt
-):
-    Ownable.assert_only_owner()
-    Module_access.write(address)
-    return ()
-end
-
-# ONLY ALLOWS MODULE TO MINT S_REALM
-
-func check_caller{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
-    value : felt
-):
-    let (address) = Module_access.read()
-    let (caller) = get_caller_address()
-
-    if address == caller:
-        return (1)
-    end
-
-    return (0)
-end
-
-func check_owner{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
-    value : felt
-):
-    let (caller) = get_caller_address()
-    let (owner) = Ownable.owner()
-
-    if caller == owner:
-        return (1)
-    end
-
-    return (0)
-end
-
-func check_can_action{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
-    let (caller) = check_caller()
-    let (owner) = check_owner()
-
-    assert_not_zero(owner + caller)
     return ()
 end

--- a/contracts/settling_game/tokens/S_Crypts_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Crypts_ERC721_Mintable.cairo
@@ -5,8 +5,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
-from starkware.starknet.common.syscalls import get_caller_address
-from starkware.cairo.common.math import assert_not_zero, assert_not_equal
 from openzeppelin.token.erc721.library import ERC721
 from openzeppelin.token.erc721_enumerable.library import ERC721_Enumerable
 from openzeppelin.introspection.ERC165 import ERC165
@@ -15,7 +13,6 @@ from openzeppelin.access.ownable import Ownable
 from openzeppelin.upgrades.library import Proxy
 
 from contracts.settling_game.utils.general import unpack_data
-from contracts.settling_game.utils.game_structs import RealmData
 
 from contracts.settling_game.library.library_module import Module
 

--- a/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
@@ -9,7 +9,6 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.cairo.common.math import assert_not_zero, assert_not_equal
 from openzeppelin.token.erc721.library import ERC721
 from openzeppelin.token.erc721_enumerable.library import ERC721_Enumerable
 from openzeppelin.introspection.ERC165 import ERC165
@@ -18,7 +17,6 @@ from openzeppelin.access.ownable import Ownable
 from openzeppelin.upgrades.library import Proxy
 
 from contracts.settling_game.utils.general import unpack_data
-from contracts.settling_game.utils.game_structs import RealmData
 
 from contracts.settling_game.library.library_module import Module
 

--- a/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
@@ -20,6 +20,8 @@ from openzeppelin.upgrades.library import Proxy
 from contracts.settling_game.utils.general import unpack_data
 from contracts.settling_game.utils.game_structs import RealmData
 
+from contracts.settling_game.library.library_module import Module
+
 #
 # Initializer
 #
@@ -178,14 +180,14 @@ end
 func mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, tokenId : Uint256
 ):
-    check_can_action()
+    Module.only_approved()
     ERC721_Enumerable._mint(to, tokenId)
     return ()
 end
 
 @external
 func burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(tokenId : Uint256):
-    check_can_action()
+    Module.only_approved()
     ERC721_Enumerable._burn(tokenId)
     return ()
 end
@@ -210,58 +212,5 @@ end
 @external
 func renounceOwnership{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     Ownable.renounce_ownership()
-    return ()
-end
-
-#
-# Bibliotheca added methods
-#
-
-@storage_var
-func Module_access() -> (address : felt):
-end
-
-@external
-func Set_module_access{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-    address : felt
-):
-    Ownable.assert_only_owner()
-    Module_access.write(address)
-    return ()
-end
-
-# ONLY ALLOWS MODULE TO MINT S_REALM
-
-func check_caller{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
-    value : felt
-):
-    let (address) = Module_access.read()
-    let (caller) = get_caller_address()
-
-    if address == caller:
-        return (1)
-    end
-
-    return (0)
-end
-
-func check_owner{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
-    value : felt
-):
-    let (caller) = get_caller_address()
-    let (owner) = Ownable.owner()
-
-    if caller == owner:
-        return (1)
-    end
-
-    return (0)
-end
-
-func check_can_action{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
-    let (caller) = check_caller()
-    let (owner) = check_owner()
-
-    assert_not_zero(owner + caller)
     return ()
 end

--- a/contracts/settling_game/utils/game_structs.cairo
+++ b/contracts/settling_game/utils/game_structs.cairo
@@ -152,7 +152,7 @@ namespace ArmyCap:
 end
 
 namespace ModuleIds:
-    const L01_Settling = 1
+    const Settling = 1
     const L02_Resources = 2
     const L03_Buildings = 3
     const L04_Calculator = 4

--- a/contracts/settling_game/utils/game_structs.cairo
+++ b/contracts/settling_game/utils/game_structs.cairo
@@ -152,7 +152,7 @@ namespace ArmyCap:
 end
 
 namespace ModuleIds:
-    const Settling = 1
+    const L01_Settling = 1
     const L02_Resources = 2
     const L03_Buildings = 3
     const L04_Calculator = 4
@@ -162,6 +162,12 @@ namespace ModuleIds:
     const L08_Crypts_Resources = 8
     const L09_Relics = 12
     const L10_Food = 13
+    const Crypts_Token = 1001
+    const Lords_Token = 1002
+    const Realms_Token = 1003
+    const Resources_Token = 1004
+    const S_Crypts_Token = 1005
+    const S_Realms_Token = 1006
 end
 
 namespace ExternalContractIds:


### PR DESCRIPTION
PR related to issue #162 

I have added `Module.only_approved()` to the token contracts asserting whether a permission is stored in `ModuleController.cairo` be called for `mint` and `burn` functions. This involved:

* Updating the token contracts
  * Added `Module.only_approved()` to functions required
  * Remove `Set_module_access` methods, this seems redundant as `ModuleController.cairo` constructor stores permissions.
* Update `ModuleController.cairo` with required permissions for tokens.\
* Update `game_structs.cairo` with module ids for token contracts starting from 1000

**Note:**

There are token contracts that aren't ever called from modules (e.g `Realms_ERC721_Mintable.cairo`). For these I have just left the current asserts (I assume you still want anyone to be able to mint a realm).

I have kept other token functions including `upgrade` the same, not sure whether `ModuleController.cairo` is involved with any others.

As discussed with @ponderingdemocritus I also haven't run tests, so please check.