### PR TITLE
feat: Add token URIs logic to resources

### DIFF
--- a/contracts/settling_game/tokens/Resources_ERC1155_Mintable_Burnable.cairo
+++ b/contracts/settling_game/tokens/Resources_ERC1155_Mintable_Burnable.cairo
@@ -53,8 +53,11 @@ func supportsInterface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_c
 end
 
 @view
-func uri{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (uri : felt):
-    return ERC1155.uri()
+func tokenURI{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    tokenId : Uint256
+) -> (tokenURI : felt):
+    let (tokenURI : felt) = ERC1155.token_uri(tokenId)
+    return (tokenURI)
 end
 
 @view
@@ -173,6 +176,15 @@ func burnBatch{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
         assert_not_zero(caller)
     end
     ERC1155._burn_batch(from_, ids_len, ids, amounts_len, amounts)
+    return ()
+end
+
+@external
+func setTokenUri{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    tokenId : Uint256, tokenURI : felt
+):
+    Ownable.assert_only_owner()
+    ERC1155._set_token_uri(tokenId, tokenURI)
     return ()
 end
 #

--- a/contracts/settling_game/tokens/Resources_ERC1155_Mintable_Burnable.cairo
+++ b/contracts/settling_game/tokens/Resources_ERC1155_Mintable_Burnable.cairo
@@ -26,7 +26,7 @@ from contracts.token.library import ERC1155
 func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     uri : felt, proxy_admin : felt
 ):
-    ERC1155.initializer(uri)
+    ERC1155.initializer()
     Ownable.initializer(proxy_admin)
     Proxy.initializer(proxy_admin)
     return ()

--- a/contracts/token/library.cairo
+++ b/contracts/token/library.cairo
@@ -64,7 +64,7 @@ func ERC1155_operator_approvals(account : felt, operator : felt) -> (approved : 
 end
 
 @storage_var
-func ERC1155_uri() -> (uri : felt):
+func ERC1155_token_uri(token_id : Uint256) -> (token_uri : felt):
 end
 
 namespace ERC1155:
@@ -72,10 +72,7 @@ namespace ERC1155:
     # Constructor
     #
 
-    func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        uri_ : felt
-    ):
-        _set_uri(uri_)
+    func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
         ERC165.register_interface(IERC1155_ID)
         ERC165.register_interface(IERC1155_METADATA_ID)
         return ()
@@ -85,9 +82,11 @@ namespace ERC1155:
     # Getters
     #
 
-    func uri{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (uri : felt):
-        let (uri) = ERC1155_uri.read()
-        return (uri)
+    func token_uri{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        token_id: Uint256
+    ) -> (token_uri : felt):
+        let (token_uri) = ERC1155_token_uri.read(token_id)
+        return (token_uri)
     end
 
     func balance_of{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
@@ -392,8 +391,11 @@ namespace ERC1155:
         return ()
     end
 
-    func _set_uri{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(newuri : felt):
-        ERC1155_uri.write(newuri)
+    func _set_token_uri{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        token_id : Uint256, token_uri : felt
+    ):
+        uint256_check(token_id)
+        ERC1155_token_uri.write(token_id, token_uri)
         return ()
     end
 


### PR DESCRIPTION
As discussed with @ponderingdemocritus, need to get the correct token URIs for the NFT contracts.

The resources had a single URI set in the constructor. I have now implemented a `setTokenURI` where an ID of the resource is mapped to the URI.

Changes:

* Update Resource contract
  * Initializer no longer takes a URI input
  * URI view method updated, convention similar to `ERC721` tokens
  * `setTokenURI` method implemented, similar to `ERC721` tokens
* Update `ERC1155` library contract, abiding by conventions of openzeppelin `ERC721` library contract

**Note**:

`library.cairo` method `_set_token_uri` has an additional check in openzeppelin `ERC721` to check whether an account holds at least one of the `token_id`. I'm not sure this is necessary, nor makes sense for `ERC1155`.

Tests have not been run, so please check accordingly.