### PR TITLE
Feat/openzeppelin upgrade

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
-[submodule "cairo_contracts"]
-	url = https://github.com/OpenZeppelin/cairo-contracts
-	path = lib/cairo_contracts
-	branch = refs/heads/v0.2.0
 [submodule "lib/cairo_erc4626"]
 	path = lib/cairo_erc4626
 	url = git@github.com:auditless/cairo-erc4626.git
+[submodule "cairo_contracts"]
+	url = https://github.com/OpenZeppelin/cairo-contracts
+	path = lib/cairo_contracts
+	branch = refs/heads/v0.3.2

--- a/contracts/desiege/01_TowerDefence.cairo
+++ b/contracts/desiege/01_TowerDefence.cairo
@@ -10,12 +10,7 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.math_cmp import is_le_felt, is_le
 from starkware.cairo.common.math import unsigned_div_rem, assert_lt
 
-from openzeppelin.access.ownable import (
-    Ownable_initializer,
-    Ownable_only_owner,
-    Ownable_transfer_ownership,
-    Ownable_get_owner,
-)
+from openzeppelin.access.ownable.library import Ownable
 
 from contracts.desiege.utils.interfaces import IModuleController, I02_TowerStorage
 from contracts.desiege.tokens.ERC1155.IERC1155_Mintable_Ownable import IERC1155
@@ -91,7 +86,7 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     blocks_per_minute.write(_blocks_per_min)
     hours_per_game.write(_hours_per_game)
 
-    Ownable_initializer(_owner)
+    Ownable.initializer(_owner)
 
     return ()
 end
@@ -134,7 +129,7 @@ func create_game{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     _init_main_health : felt
 ):
     alloc_locals
-    Ownable_only_owner()
+    Ownable.assert_only_owner()
 
     let (local controller) = controller_address.read()
 
@@ -461,7 +456,7 @@ end
 func get_owner{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
     owner : felt
 ):
-    let (o) = Ownable_get_owner()
+    let (o) = Ownable.owner()
     return (owner=o)
 end
 
@@ -469,6 +464,6 @@ end
 func transfer_ownership{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     next_owner : felt
 ):
-    Ownable_transfer_ownership(next_owner)
+    Ownable.transfer_ownership(next_owner)
     return ()
 end

--- a/contracts/desiege/04_Elements.cairo
+++ b/contracts/desiege/04_Elements.cairo
@@ -3,12 +3,7 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
 
-from openzeppelin.access.ownable import (
-    Ownable_initializer,
-    Ownable_only_owner,
-    Ownable_transfer_ownership,
-    Ownable_get_owner,
-)
+from openzeppelin.access.ownable.library import Ownable
 
 from contracts.desiege.utils.interfaces import (
     IModuleController,
@@ -46,7 +41,7 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     elements_token_address.write(address_of_elements_token)
 
     # Minting is controlled by an account
-    Ownable_initializer(address_of_minting_middleware)
+    Ownable.initializer(address_of_minting_middleware)
 
     return ()
 end
@@ -59,7 +54,7 @@ func mint_elements{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check
 ):
     alloc_locals
 
-    Ownable_only_owner()
+    Ownable.assert_only_owner()
 
     # Ensure user hasn't minted for the next game
     let (local controller) = controller_address.read()
@@ -109,7 +104,7 @@ func transfer_ownership{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_
 ):
     alloc_locals
     # Transfer ownership of this contract
-    Ownable_transfer_ownership(next_owner)
+    Ownable.transfer_ownership(next_owner)
 
     # Transfer ownership of the 1155 token contract
     let (local element_token) = elements_token_address.read()

--- a/contracts/desiege/tokens/ERC1155/ERC1155_Mintable_Ownable.cairo
+++ b/contracts/desiege/tokens/ERC1155/ERC1155_Mintable_Ownable.cairo
@@ -7,12 +7,7 @@ from starkware.cairo.common.alloc import alloc
 
 from contracts.desiege.tokens.ERC1155.structs import TokenUri
 
-from openzeppelin.access.ownable import (
-    Ownable_initializer,
-    Ownable_get_owner,
-    Ownable_transfer_ownership,
-    Ownable_only_owner,
-)
+from openzeppelin.access.ownable.library import Ownable
 
 from contracts.desiege.tokens.ERC1155.ERC1155_base import (
     ERC1155_initializer,
@@ -36,7 +31,7 @@ from contracts.desiege.tokens.ERC1155.ERC1155_base import (
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(owner : felt):
-    Ownable_initializer(owner)
+    Ownable.initializer(owner)
     return ()
 end
 
@@ -86,7 +81,7 @@ end
 func mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     recipient : felt, token_id : felt, amount : felt
 ) -> ():
-    Ownable_only_owner()
+    Ownable.assert_only_owner()
     ERC1155_mint(recipient, token_id, amount)
 
     return ()
@@ -96,7 +91,7 @@ end
 func mintBatch{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     recipient : felt, token_ids_len : felt, token_ids : felt*, amounts_len : felt, amounts : felt*
 ) -> ():
-    Ownable_only_owner()
+    Ownable.assert_only_owner()
     ERC1155_mint_batch(recipient, token_ids_len, token_ids, amounts_len, amounts)
 
     return ()
@@ -106,7 +101,7 @@ end
 func burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     account : felt, token_id : felt, amount : felt
 ):
-    Ownable_only_owner()
+    Ownable.assert_only_owner()
     ERC1155_burn(account, token_id, amount)
 
     return ()
@@ -116,7 +111,7 @@ end
 func burnBatch{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     account : felt, token_ids_len : felt, token_ids : felt*, amounts_len : felt, amounts : felt*
 ):
-    Ownable_only_owner()
+    Ownable.assert_only_owner()
     ERC1155_burn_batch(account, token_ids_len, token_ids, amounts_len, amounts)
 
     return ()
@@ -129,7 +124,7 @@ end
 func getOwner{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
     owner : felt
 ):
-    let (o) = Ownable_get_owner()
+    let (o) = Ownable.owner()
     return (owner=o)
 end
 
@@ -137,6 +132,6 @@ end
 func transferOwnership{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     next_owner : felt
 ):
-    Ownable_transfer_ownership(next_owner)
+    Ownable.transfer_ownership(next_owner)
     return ()
 end

--- a/contracts/exchange/Exchange_ERC20_1155.cairo
+++ b/contracts/exchange/Exchange_ERC20_1155.cairo
@@ -20,7 +20,7 @@ from starkware.cairo.common.uint256 import (
     uint256_eq,
 )
 
-from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
+from openzeppelin.token.erc20.IERC20 import IERC20
 from contracts.settling_game.interfaces.IERC1155 import IERC1155
 
 from contracts.token.constants import (
@@ -32,11 +32,11 @@ from contracts.token.constants import (
     ON_ERC1155_BATCH_RECEIVED_SELECTOR,
 )
 
-from openzeppelin.access.ownable import Ownable
+from openzeppelin.access.ownable.library import Ownable
 
 from openzeppelin.upgrades.library import Proxy
 
-from openzeppelin.introspection.ERC165 import ERC165
+from openzeppelin.introspection.erc165.library import ERC165
 
 # move to OZ lib once live
 from contracts.token.library import ERC1155

--- a/contracts/settling_game/Arbiter.cairo
+++ b/contracts/settling_game/Arbiter.cairo
@@ -16,7 +16,7 @@ from starkware.cairo.common.math import assert_not_zero
 from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.bool import TRUE, FALSE
 
-from openzeppelin.access.ownable import Ownable
+from openzeppelin.access.ownable.library import Ownable
 
 from contracts.settling_game.interfaces.imodules import IModuleController
 

--- a/contracts/settling_game/L02_Resources.cairo
+++ b/contracts/settling_game/L02_Resources.cairo
@@ -14,8 +14,8 @@ from starkware.starknet.common.syscalls import get_caller_address, get_block_tim
 from starkware.cairo.common.uint256 import Uint256, uint256_lt
 from starkware.cairo.common.bool import TRUE, FALSE
 
-from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
-from openzeppelin.token.erc721.interfaces.IERC721 import IERC721
+from openzeppelin.token.erc20.IERC20 import IERC20
+from openzeppelin.token.erc721.IERC721 import IERC721
 from openzeppelin.upgrades.library import Proxy
 
 from contracts.settling_game.utils.game_structs import (

--- a/contracts/settling_game/L03_Buildings.cairo
+++ b/contracts/settling_game/L03_Buildings.cairo
@@ -15,7 +15,7 @@ from starkware.starknet.common.syscalls import get_caller_address, get_block_tim
 from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
+from openzeppelin.token.erc20.IERC20 import IERC20
 from openzeppelin.upgrades.library import Proxy
 
 from contracts.settling_game.library.library_buildings import Buildings

--- a/contracts/settling_game/L06_Combat.cairo
+++ b/contracts/settling_game/L06_Combat.cairo
@@ -19,7 +19,7 @@ from starkware.starknet.common.syscalls import (
 )
 
 from openzeppelin.upgrades.library import Proxy
-from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
+from openzeppelin.token.erc20.IERC20 import IERC20
 
 from contracts.settling_game.interfaces.IERC1155 import IERC1155
 from contracts.settling_game.modules.calculator.interface import ICalculator

--- a/contracts/settling_game/library/library_module.cairo
+++ b/contracts/settling_game/library/library_module.cairo
@@ -25,7 +25,7 @@ from starkware.cairo.common.uint256 import (
 )
 from starkware.cairo.common.bool import TRUE, FALSE
 
-from openzeppelin.token.erc721.interfaces.IERC721 import IERC721
+from openzeppelin.token.erc721.IERC721 import IERC721
 
 from contracts.settling_game.interfaces.imodules import IModuleController
 

--- a/contracts/settling_game/modules/crypts/L07_Crypts.cairo
+++ b/contracts/settling_game/modules/crypts/L07_Crypts.cairo
@@ -15,7 +15,7 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.bool import TRUE
 
 from openzeppelin.upgrades.library import Proxy
-from openzeppelin.token.erc721.interfaces.IERC721 import IERC721
+from openzeppelin.token.erc721.IERC721 import IERC721
 
 from contracts.settling_game.utils.game_structs import ModuleIds, ExternalContractIds
 

--- a/contracts/settling_game/modules/crypts/L08_Crypts_Resources.cairo
+++ b/contracts/settling_game/modules/crypts/L08_Crypts_Resources.cairo
@@ -13,7 +13,7 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.bool import TRUE, FALSE
 
 from openzeppelin.upgrades.library import Proxy
-from openzeppelin.token.erc721.interfaces.IERC721 import IERC721
+from openzeppelin.token.erc721.IERC721 import IERC721
 
 from contracts.settling_game.utils.game_structs import (
     CryptData,

--- a/contracts/settling_game/tokens/Crypts_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/Crypts_ERC721_Mintable.cairo
@@ -10,9 +10,9 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin,
 from starkware.cairo.common.uint256 import Uint256
 
 from openzeppelin.token.erc721.library import ERC721
-from openzeppelin.token.erc721_enumerable.library import ERC721_Enumerable
-from openzeppelin.introspection.ERC165 import ERC165
-from openzeppelin.access.ownable import Ownable
+from openzeppelin.token.erc721.enumerable.library import ERC721Enumerable
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.access.ownable.library import Ownable
 
 from openzeppelin.upgrades.library import Proxy
 
@@ -28,7 +28,7 @@ func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     name : felt, symbol : felt, proxy_admin : felt
 ):
     ERC721.initializer(name, symbol)
-    ERC721_Enumerable.initializer()
+    ERC721Enumerable.initializer()
     Ownable.initializer(proxy_admin)
     Proxy.initializer(proxy_admin)
     return ()
@@ -51,7 +51,7 @@ end
 func totalSupply{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC721_Enumerable.total_supply()
+    let (totalSupply : Uint256) = ERC721Enumerable.total_supply()
     return (totalSupply)
 end
 
@@ -59,7 +59,7 @@ end
 func tokenByIndex{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     index : Uint256
 ) -> (tokenId : Uint256):
-    let (tokenId : Uint256) = ERC721_Enumerable.token_by_index(index)
+    let (tokenId : Uint256) = ERC721Enumerable.token_by_index(index)
     return (tokenId)
 end
 
@@ -67,7 +67,7 @@ end
 func tokenOfOwnerByIndex{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     owner : felt, index : Uint256
 ) -> (tokenId : Uint256):
-    let (tokenId : Uint256) = ERC721_Enumerable.token_of_owner_by_index(owner, index)
+    let (tokenId : Uint256) = ERC721Enumerable.token_of_owner_by_index(owner, index)
     return (tokenId)
 end
 
@@ -161,7 +161,7 @@ end
 func transferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     from_ : felt, to : felt, tokenId : Uint256
 ):
-    ERC721_Enumerable.transfer_from(from_, to, tokenId)
+    ERC721Enumerable.transfer_from(from_, to, tokenId)
     return ()
 end
 
@@ -169,7 +169,7 @@ end
 func safeTransferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     from_ : felt, to : felt, tokenId : Uint256, data_len : felt, data : felt*
 ):
-    ERC721_Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data)
+    ERC721Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data)
     return ()
 end
 
@@ -178,14 +178,14 @@ func mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, tokenId : Uint256
 ):
     Ownable.assert_only_owner()
-    ERC721_Enumerable._mint(to, tokenId)
+    ERC721Enumerable._mint(to, tokenId)
     return ()
 end
 
 @external
 func burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(tokenId : Uint256):
     ERC721.assert_only_token_owner(tokenId)
-    ERC721_Enumerable._burn(tokenId)
+    ERC721Enumerable._burn(tokenId)
     return ()
 end
 

--- a/contracts/settling_game/tokens/Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/Realms_ERC721_Mintable.cairo
@@ -10,9 +10,9 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin,
 from starkware.cairo.common.uint256 import Uint256
 
 from openzeppelin.token.erc721.library import ERC721
-from openzeppelin.token.erc721_enumerable.library import ERC721_Enumerable
-from openzeppelin.introspection.ERC165 import ERC165
-from openzeppelin.access.ownable import Ownable
+from openzeppelin.token.erc721.enumerable.library import ERC721Enumerable
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.access.ownable.library import Ownable
 
 from openzeppelin.upgrades.library import Proxy
 
@@ -28,7 +28,7 @@ func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     name : felt, symbol : felt, proxy_admin : felt
 ):
     ERC721.initializer(name, symbol)
-    ERC721_Enumerable.initializer()
+    ERC721Enumerable.initializer()
     Ownable.initializer(proxy_admin)
     Proxy.initializer(proxy_admin)
     return ()
@@ -51,7 +51,7 @@ end
 func totalSupply{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC721_Enumerable.total_supply()
+    let (totalSupply : Uint256) = ERC721Enumerable.total_supply()
     return (totalSupply)
 end
 
@@ -59,7 +59,7 @@ end
 func tokenByIndex{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     index : Uint256
 ) -> (tokenId : Uint256):
-    let (tokenId : Uint256) = ERC721_Enumerable.token_by_index(index)
+    let (tokenId : Uint256) = ERC721Enumerable.token_by_index(index)
     return (tokenId)
 end
 
@@ -67,7 +67,7 @@ end
 func tokenOfOwnerByIndex{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     owner : felt, index : Uint256
 ) -> (tokenId : Uint256):
-    let (tokenId : Uint256) = ERC721_Enumerable.token_of_owner_by_index(owner, index)
+    let (tokenId : Uint256) = ERC721Enumerable.token_of_owner_by_index(owner, index)
     return (tokenId)
 end
 
@@ -161,7 +161,7 @@ end
 func transferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     from_ : felt, to : felt, tokenId : Uint256
 ):
-    ERC721_Enumerable.transfer_from(from_, to, tokenId)
+    ERC721Enumerable.transfer_from(from_, to, tokenId)
     return ()
 end
 
@@ -169,7 +169,7 @@ end
 func safeTransferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     from_ : felt, to : felt, tokenId : Uint256, data_len : felt, data : felt*
 ):
-    ERC721_Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data)
+    ERC721Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data)
     return ()
 end
 
@@ -178,14 +178,14 @@ func mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, tokenId : Uint256
 ):
     # Ownable.assert_only_owner()
-    ERC721_Enumerable._mint(to, tokenId)
+    ERC721Enumerable._mint(to, tokenId)
     return ()
 end
 
 @external
 func burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(tokenId : Uint256):
     ERC721.assert_only_token_owner(tokenId)
-    ERC721_Enumerable._burn(tokenId)
+    ERC721Enumerable._burn(tokenId)
     return ()
 end
 

--- a/contracts/settling_game/tokens/Resources_ERC1155_Mintable_Burnable.cairo
+++ b/contracts/settling_game/tokens/Resources_ERC1155_Mintable_Burnable.cairo
@@ -9,11 +9,11 @@ from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.bool import TRUE, FALSE
 
-from openzeppelin.access.ownable import Ownable
+from openzeppelin.access.ownable.library import Ownable
 
 from openzeppelin.upgrades.library import Proxy
 
-from openzeppelin.introspection.ERC165 import ERC165
+from openzeppelin.introspection.erc165.library import ERC165
 
 from contracts.settling_game.library.library_module import Module
 

--- a/contracts/settling_game/tokens/S_Crypts_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Crypts_ERC721_Mintable.cairo
@@ -6,9 +6,9 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
 from openzeppelin.token.erc721.library import ERC721
-from openzeppelin.token.erc721_enumerable.library import ERC721_Enumerable
-from openzeppelin.introspection.ERC165 import ERC165
-from openzeppelin.access.ownable import Ownable
+from openzeppelin.token.erc721.enumerable.library import ERC721Enumerable
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.access.ownable.library import Ownable
 
 from openzeppelin.upgrades.library import Proxy
 
@@ -25,7 +25,7 @@ func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     name : felt, symbol : felt, proxy_admin : felt
 ):
     ERC721.initializer(name, symbol)
-    ERC721_Enumerable.initializer()
+    ERC721Enumerable.initializer()
     Ownable.initializer(proxy_admin)
     Proxy.initializer(proxy_admin)
     return ()
@@ -48,7 +48,7 @@ end
 func totalSupply{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC721_Enumerable.total_supply()
+    let (totalSupply : Uint256) = ERC721Enumerable.total_supply()
     return (totalSupply)
 end
 
@@ -56,7 +56,7 @@ end
 func tokenByIndex{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     index : Uint256
 ) -> (tokenId : Uint256):
-    let (tokenId : Uint256) = ERC721_Enumerable.token_by_index(index)
+    let (tokenId : Uint256) = ERC721Enumerable.token_by_index(index)
     return (tokenId)
 end
 
@@ -64,7 +64,7 @@ end
 func tokenOfOwnerByIndex{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     owner : felt, index : Uint256
 ) -> (tokenId : Uint256):
-    let (tokenId : Uint256) = ERC721_Enumerable.token_of_owner_by_index(owner, index)
+    let (tokenId : Uint256) = ERC721Enumerable.token_of_owner_by_index(owner, index)
     return (tokenId)
 end
 
@@ -158,7 +158,7 @@ end
 func transferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     from_ : felt, to : felt, tokenId : Uint256
 ):
-    ERC721_Enumerable.transfer_from(from_, to, tokenId)
+    ERC721Enumerable.transfer_from(from_, to, tokenId)
     return ()
 end
 
@@ -166,7 +166,7 @@ end
 func safeTransferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     from_ : felt, to : felt, tokenId : Uint256, data_len : felt, data : felt*
 ):
-    ERC721_Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data)
+    ERC721Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data)
     return ()
 end
 
@@ -175,14 +175,14 @@ func mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, tokenId : Uint256
 ):
     Module.only_approved()
-    ERC721_Enumerable._mint(to, tokenId)
+    ERC721Enumerable._mint(to, tokenId)
     return ()
 end
 
 @external
 func burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(tokenId : Uint256):
     Module.only_approved()
-    ERC721_Enumerable._burn(tokenId)
+    ERC721Enumerable._burn(tokenId)
     return ()
 end
 

--- a/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
@@ -10,9 +10,9 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin,
 from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import get_caller_address
 from openzeppelin.token.erc721.library import ERC721
-from openzeppelin.token.erc721_enumerable.library import ERC721_Enumerable
-from openzeppelin.introspection.ERC165 import ERC165
-from openzeppelin.access.ownable import Ownable
+from openzeppelin.token.erc721.enumerable.library import ERC721Enumerable
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.access.ownable.library import Ownable
 
 from openzeppelin.upgrades.library import Proxy
 
@@ -29,7 +29,7 @@ func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     name : felt, symbol : felt, proxy_admin : felt
 ):
     ERC721.initializer(name, symbol)
-    ERC721_Enumerable.initializer()
+    ERC721Enumerable.initializer()
     Ownable.initializer(proxy_admin)
     Proxy.initializer(proxy_admin)
     return ()
@@ -52,7 +52,7 @@ end
 func totalSupply{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC721_Enumerable.total_supply()
+    let (totalSupply : Uint256) = ERC721Enumerable.total_supply()
     return (totalSupply)
 end
 
@@ -60,7 +60,7 @@ end
 func tokenByIndex{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     index : Uint256
 ) -> (tokenId : Uint256):
-    let (tokenId : Uint256) = ERC721_Enumerable.token_by_index(index)
+    let (tokenId : Uint256) = ERC721Enumerable.token_by_index(index)
     return (tokenId)
 end
 
@@ -68,7 +68,7 @@ end
 func tokenOfOwnerByIndex{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     owner : felt, index : Uint256
 ) -> (tokenId : Uint256):
-    let (tokenId : Uint256) = ERC721_Enumerable.token_of_owner_by_index(owner, index)
+    let (tokenId : Uint256) = ERC721Enumerable.token_of_owner_by_index(owner, index)
     return (tokenId)
 end
 
@@ -162,7 +162,7 @@ end
 func transferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     from_ : felt, to : felt, tokenId : Uint256
 ):
-    ERC721_Enumerable.transfer_from(from_, to, tokenId)
+    ERC721Enumerable.transfer_from(from_, to, tokenId)
     return ()
 end
 
@@ -170,7 +170,7 @@ end
 func safeTransferFrom{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     from_ : felt, to : felt, tokenId : Uint256, data_len : felt, data : felt*
 ):
-    ERC721_Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data)
+    ERC721Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data)
     return ()
 end
 
@@ -179,14 +179,14 @@ func mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     to : felt, tokenId : Uint256
 ):
     Module.only_approved()
-    ERC721_Enumerable._mint(to, tokenId)
+    ERC721Enumerable._mint(to, tokenId)
     return ()
 end
 
 @external
 func burn{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(tokenId : Uint256):
     Module.only_approved()
-    ERC721_Enumerable._burn(tokenId)
+    ERC721Enumerable._burn(tokenId)
     return ()
 end
 

--- a/contracts/staking/SingleSidedStaking.cairo
+++ b/contracts/staking/SingleSidedStaking.cairo
@@ -7,8 +7,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
 from starkware.cairo.common.uint256 import ALL_ONES, Uint256, uint256_check, uint256_eq
 
-from openzeppelin.security.safemath import SafeUint256
-from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
+from openzeppelin.security.safemath.library import SafeUint256
+from openzeppelin.token.erc20.IERC20 import IERC20
 from openzeppelin.token.erc20.library import ERC20
 from openzeppelin.upgrades.library import Proxy
 

--- a/contracts/staking/Splitter.cairo
+++ b/contracts/staking/Splitter.cairo
@@ -7,8 +7,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
 from starkware.cairo.common.uint256 import ALL_ONES, Uint256, uint256_check, uint256_eq
 
-from openzeppelin.security.safemath import SafeUint256
-from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
+from openzeppelin.security.safemath.library import SafeUint256
+from openzeppelin.token.erc20.IERC20 import IERC20
 from openzeppelin.token.erc20.library import ERC20
 from openzeppelin.upgrades.library import Proxy
 

--- a/contracts/token/ERC1155_Mintable_Burnable.cairo
+++ b/contracts/token/ERC1155_Mintable_Burnable.cairo
@@ -9,11 +9,11 @@ from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.bool import TRUE, FALSE
 
-from openzeppelin.access.ownable import Ownable
+from openzeppelin.access.ownable.library import Ownable
 
 from openzeppelin.upgrades.library import Proxy
 
-from openzeppelin.introspection.ERC165 import ERC165
+from openzeppelin.introspection.erc165.library import ERC165
 
 # move to OZ lib once live
 from contracts.token.library import ERC1155

--- a/contracts/token/library.cairo
+++ b/contracts/token/library.cairo
@@ -10,10 +10,10 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.uint256 import Uint256, uint256_check
 from starkware.cairo.common.bool import TRUE, FALSE
 
-from openzeppelin.introspection.IERC165 import IERC165
-from openzeppelin.introspection.ERC165 import ERC165
+from openzeppelin.introspection.erc165.IERC165 import IERC165
+from openzeppelin.introspection.erc165.library import ERC165
 from contracts.token.interfaces.IERC1155_Receiver import IERC1155_Receiver
-from openzeppelin.security.safemath import SafeUint256
+from openzeppelin.security.safemath.library import SafeUint256
 from contracts.token.constants import (
     IERC1155_ID,
     IERC1155_METADATA_ID,

--- a/contracts/yagi/erc4626/ERC4626.cairo
+++ b/contracts/yagi/erc4626/ERC4626.cairo
@@ -7,7 +7,7 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
 from starkware.cairo.common.uint256 import ALL_ONES, Uint256, uint256_check, uint256_eq
 
-from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
+from openzeppelin.token.erc20.IERC20 import IERC20
 from openzeppelin.token.erc20.library import ERC20
 
 from contracts.yagi.erc4626.library import ERC4626, ERC4626_asset, Deposit, Withdraw

--- a/contracts/yagi/erc4626/library.cairo
+++ b/contracts/yagi/erc4626/library.cairo
@@ -7,9 +7,9 @@ from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.uint256 import ALL_ONES, Uint256, uint256_check, uint256_eq
 from starkware.starknet.common.syscalls import get_caller_address, get_contract_address
 
-from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
+from openzeppelin.token.erc20.IERC20 import IERC20
 from openzeppelin.token.erc20.library import ERC20, ERC20_allowances
-from openzeppelin.security.safemath import SafeUint256
+from openzeppelin.security.safemath.library import SafeUint256
 
 from contracts.yagi.utils.fixedpointmathlib import mul_div_up, mul_div_down
 

--- a/contracts/yagi/utils/fixedpointmathlib.cairo
+++ b/contracts/yagi/utils/fixedpointmathlib.cairo
@@ -4,7 +4,7 @@ from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.uint256 import Uint256, uint256_add, uint256_eq, uint256_sub
-from openzeppelin.security.safemath import SafeUint256
+from openzeppelin.security.safemath.library import SafeUint256
 
 # # @title Fixed point math library
 # # @description A fixed point math library


### PR DESCRIPTION
As mentioned in #184 I have updated the contracts to be `OpenZeppelin/cairo-contracts@v0.3.2` compatible and updated the protostar dependency.

Should be mostly self explanatory, I have run `nile compile` and confirm no errors in openzeppelin libraries. There are still some contract errors that appear which I haven't changed.

Unsure if any updates to tests are required? I can't figure out where `lib.cairo_math64x61` comes from in some of the tests, is this deprecated?

Once this update is merged the guilds implementation can also finish, as it means they can integrate.