### PR TITLE
fix: upgrade to `cairo-nile==0.8.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ base58==2.1.1
 bitarray==1.2.2
 cachetools==4.2.4
 cairo-lang==0.9.1
-cairo-nile==0.7.1
+cairo-nile==0.8.2
 certifi==2021.10.8
 charset-normalizer==2.0.7
 click==8.0.4


### PR DESCRIPTION
Upgrade `cairo-nile` so it is compatible with `cairo-lang==0.9.1`.

Only changed requirements, unsure of anywhere else that needs changing? Perhaps github actions?