### PR TITLE
fix: fix the updated state to item_address when set_loot

### DIFF
--- a/contracts/loot/adventurer/Adventurer.cairo
+++ b/contracts/loot/adventurer/Adventurer.cairo
@@ -311,7 +311,7 @@ func get_lords{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 @external
 func set_loot{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(loot: felt) {
     Proxy.assert_only_admin();
-    lords_address.write(loot);
+    item_address.write(loot);
     return ();
 }
 


### PR DESCRIPTION
fix the updated state to item_address when set_loot