### PR TITLE
remove module_05 in batch_set_controller_addresses (issue #219)

### DIFF
--- a/contracts/settling_game/ModuleController.cairo
+++ b/contracts/settling_game/ModuleController.cairo
@@ -185,7 +185,6 @@ func set_initial_module_addresses{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*
     resources_module_addr: felt,
     buildings_module_addr: felt,
     calculator_module_addr: felt,
-    module_05_addr: felt,
     module_06_addr: felt,
 ) {
     only_arbiter();


### PR DESCRIPTION
Following issue #219 and noticing that in the `IModuleController` and `ModuleIds` constant didn't have a 5th module, I assumed you guys wanted to remove it so I made this PR removing the module_05 argument in the `ModuleController::set_initial_module_addresses` function.