### PR TITLE
initialize controlle in S_Realms

### DIFF
--- a/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
@@ -26,12 +26,13 @@ from contracts.settling_game.library.library_module import Module
 
 @external
 func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    name: felt, symbol: felt, proxy_admin: felt
+    name: felt, symbol: felt, proxy_admin: felt, module_controller_address: felt
 ) {
     ERC721.initializer(name, symbol);
     ERC721Enumerable.initializer();
     Ownable.initializer(proxy_admin);
     Proxy.initializer(proxy_admin);
+    Module.initializer(module_controller_address);
     return ();
 }
 


### PR DESCRIPTION
When you want a settled Realm NFT, you first settle your Realm NFT via `Settling.cairo` which will take your Realm and mint you an SRealm by calling `S_Realms_ERC721_Mintable::mint`:

```cairo
@external
func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
    to: felt, tokenId: Uint256
) {
    Module.only_approved();
    ERC721Enumerable._mint(to, tokenId);
    return ();
}
```

This call `Module.only_aproved()`:
```cairo
    func only_approved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
        alloc_locals;
        let (success) = _only_approved();
        let (self) = check_self();
        assert_not_zero(success + self);
        return ();
    }
```

which then call `_only_approved`:
```cairo
    func _only_approved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
        success: felt
    ) {
        let (caller) = get_caller_address();
        let (controller) = module_controller_address.read();

        // Pass this address on to the ModuleController
        // Will revert the transaction if not.
        let (success) = IModuleController.has_write_access(controller, caller);
        return (success,);
    }
```

And here the contract making the check (here `S_Realms_ERC721_Mintable.cairo`) is getting the module controller address. Except it can't find it and return the following error: 
```
     StarknetPluginError: Invoke transaction 0x5024d494400e61dfa479baa6aa1d1386708499b7d2ba609008bf75872a9a12d: Error: Transaction rejected. Error message:

Error at pc=0:25:
Got an exception while executing a hint.
Cairo traceback (most recent call last):
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:253)
Unknown location (pc=0:237)

Error in the called contract (0x1e44ee3c29237836876fae4cec7e7831072c7bc0f6e99b08bb6cf98d07b8887):
/usr/local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo:52:5: Error at pc=0:74:
Got an exception while executing a hint.
Cairo traceback (most recent call last):
/Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/contracts/settling_game/modules/settling/Settling.cairo:104:6: (pc=0:1078)
func settle{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(token_id: Uint256) -> (
     ^****^
/Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/contracts/settling_game/modules/settling/Settling.cairo:119:5: (pc=0:1019)
    IMintable.mint(s_realms_address, caller, token_id);
    ^************************************************^
autogen/starknet/contract_interface/IMintable/mint/304ae580b78eb48c6532c7788d73eef2a89dcd3c406dfb71c0bdbeacea1728ca.cairo:2:31: (pc=0:570)
let (retdata_size, retdata) = call_contract(
                              ^************^

Error in the called contract (0x1b7829c350c47970b6574f57c7bc051453e20e2ee05ff6b8763eef2cf665cd1):
/usr/local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo:52:5: Error at pc=0:170:
Got an exception while executing a hint.
Cairo traceback (most recent call last):
/Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo:178:6: (pc=0:3384)
func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
     ^**^
/Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo:181:5: (pc=0:3364)
    Module.only_approved();
    ^********************^
/Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/contracts/settling_game/library/library_module.cairo:66:25: (pc=0:2688)
        let (success) = _only_approved();
                        ^**************^
/Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/contracts/settling_game/library/library_module.cairo:165:25: (pc=0:2736)
        let (success) = IModuleController.has_write_access(controller, caller);
                        ^****************************************************^
autogen/starknet/contract_interface/IModuleController/has_write_access/681a28f977f0877a77bff594bc3e8d3700bccde84864562fac1ada82244a9229.cairo:2:31: (pc=0:2656)
let (retdata_size, retdata) = call_contract(
                              ^************^

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/starkware/starknet/common/syscalls.cairo", line 52, in <module>
  File "/Users/dsi/cairo_venv/lib/python3.9/site-packages/starkware/starknet/core/os/syscall_utils.py", line 221, in call_contract
    self._call_contract_and_write_response(
  File "/Users/dsi/cairo_venv/lib/python3.9/site-packages/starkware/starknet/core/os/syscall_utils.py", line 499, in _call_contract_and_write_response
    retdata = self._call_contract(
  File "/Users/dsi/cairo_venv/lib/python3.9/site-packages/starkware/starknet/core/os/syscall_utils.py", line 711, in _call_contract
    call = self.execute_entry_point_cls(
  File "<string>", line 11, in __init__
  File "/Users/dsi/cairo_venv/lib/python3.9/site-packages/starkware/starkware_utils/validated_dataclass.py", line 24, in __post_init__
    self.validate_dataclass()
  File "/Users/dsi/cairo_venv/lib/python3.9/site-packages/starkware/starkware_utils/validated_dataclass.py", line 28, in validate_dataclass
    self.validate_values()
  File "/Users/dsi/cairo_venv/lib/python3.9/site-packages/starkware/starkware_utils/validated_dataclass.py", line 115, in validate_values
    validated_field.validate(value=value, name=name_in_messages)
  File "/Users/dsi/cairo_venv/lib/python3.9/site-packages/starkware/starkware_utils/validated_fields.py", line 76, in validate
    stark_assert(self.is_valid(value=value), code=self.error_code, message=error_message)
  File "/Users/dsi/cairo_venv/lib/python3.9/site-packages/starkware/starkware_utils/error_handling.py", line 180, in stark_assert
    raise StarkException(code=code, message=message)
starkware.starkware_utils.error_handling.StarkException: (500, {'code': <StarknetErrorCode.OUT_OF_RANGE_CONTRACT_ADDRESS: 30>, 'message': 'contract address 0x0 is out of range'})
      at /Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/node_modules/@shardlabs/starknet-hardhat-plugin/src/types.ts:632:28
      at /Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/node_modules/@shardlabs/starknet-hardhat-plugin/src/types.ts:201:9
      at Generator.next (<anonymous>)
      at fulfilled (/Users/dsi/Documents/Workspace/my-projects/realms-contracts-hardhat/node_modules/@shardlabs/starknet-hardhat-plugin/dist/src/types.js:28:58)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

Result:

I initialized the module controller address in the S_Realm_ERC721_Mintable initalizer