### PR TITLE
refactor: no packing inside lib

### DIFF
--- a/contracts/settling_game/modules/combat/Combat.cairo
+++ b/contracts/settling_game/modules/combat/Combat.cairo
@@ -319,12 +319,8 @@ func initiate_combat{
     // luck role and then outcome
     let (luck) = roll_dice();
     let (
-        combat_outcome, ending_attacking_army_packed, ending_defending_army_packed
-    ) = Combat.calculate_winner(luck, attacking_realm_data.packed, defending_realm_data.packed);
-
-    // unpack
-    let (ending_attacking_army: Army) = Combat.unpack_army(ending_attacking_army_packed);
-    let (ending_defending_army: Army) = Combat.unpack_army(ending_defending_army_packed);
+        combat_outcome, ending_attacking_army, ending_defending_army
+    ) = Combat.calculate_winner(luck, starting_attack_army, starting_defend_army);
 
     // pillaging only if attacker wins
     let (now) = get_block_timestamp();
@@ -357,6 +353,9 @@ func initiate_combat{
 
     tempvar attacking_xp = attacking_xp;
     tempvar defending_xp = defending_xp;
+
+    let (ending_attacking_army_packed: felt) = Combat.pack_army(ending_attacking_army);
+    let (ending_defending_army_packed: felt) = Combat.pack_army(ending_defending_army);
 
     // store new values with added XP
     set_army_data_and_emit(

--- a/contracts/settling_game/modules/combat/library.cairo
+++ b/contracts/settling_game/modules/combat/library.cairo
@@ -139,23 +139,23 @@ namespace Combat {
     }(army_unpacked: Army) -> (packed_army: felt) {
         alloc_locals;
 
-        let light_cavalry_quantity = army_unpacked.LightCavalry.Quantity * SHIFT_ARMY._1;
-        let heavy_cavalry_quantity = army_unpacked.HeavyCavalry.Quantity * SHIFT_ARMY._2;
-        let archer_quantity = army_unpacked.Archer.Quantity * SHIFT_ARMY._3;
-        let longbow_quantity = army_unpacked.Longbow.Quantity * SHIFT_ARMY._4;
-        let mage_quantity = army_unpacked.Mage.Quantity * SHIFT_ARMY._5;
-        let archanist_quantity = army_unpacked.Arcanist.Quantity * SHIFT_ARMY._6;
-        let light_infantry_quantity = army_unpacked.LightInfantry.Quantity * SHIFT_ARMY._7;
-        let heavy_infantry_quantity = army_unpacked.HeavyInfantry.Quantity * SHIFT_ARMY._8;
+        let light_cavalry_quantity = army_unpacked.light_cavalry.quantity * SHIFT_ARMY._1;
+        let heavy_cavalry_quantity = army_unpacked.heavy_cavalry.quantity * SHIFT_ARMY._2;
+        let archer_quantity = army_unpacked.archer.quantity * SHIFT_ARMY._3;
+        let longbow_quantity = army_unpacked.longbow.quantity * SHIFT_ARMY._4;
+        let mage_quantity = army_unpacked.mage.quantity * SHIFT_ARMY._5;
+        let archanist_quantity = army_unpacked.arcanist.quantity * SHIFT_ARMY._6;
+        let light_infantry_quantity = army_unpacked.light_infantry.quantity * SHIFT_ARMY._7;
+        let heavy_infantry_quantity = army_unpacked.heavy_infantry.quantity * SHIFT_ARMY._8;
 
-        let light_cavalry_health = army_unpacked.LightCavalry.Health * SHIFT_ARMY._9;
-        let heavy_cavalry_health = army_unpacked.HeavyCavalry.Health * SHIFT_ARMY._10;
-        let archer_health = army_unpacked.Archer.Health * SHIFT_ARMY._11;
-        let longbow_health = army_unpacked.Longbow.Health * SHIFT_ARMY._12;
-        let mage_health = army_unpacked.Mage.Health * SHIFT_ARMY._13;
-        let arcanist_health = army_unpacked.Arcanist.Health * SHIFT_ARMY._14;
-        let light_infantry_health = army_unpacked.LightInfantry.Health * SHIFT_ARMY._15;
-        let heavy_infantry_health = army_unpacked.HeavyInfantry.Health * SHIFT_ARMY._16;
+        let light_cavalry_health = army_unpacked.light_cavalry.health * SHIFT_ARMY._9;
+        let heavy_cavalry_health = army_unpacked.heavy_cavalry.health * SHIFT_ARMY._10;
+        let archer_health = army_unpacked.archer.health * SHIFT_ARMY._11;
+        let longbow_health = army_unpacked.longbow.health * SHIFT_ARMY._12;
+        let mage_health = army_unpacked.mage.health * SHIFT_ARMY._13;
+        let arcanist_health = army_unpacked.arcanist.health * SHIFT_ARMY._14;
+        let light_infantry_health = army_unpacked.light_infantry.health * SHIFT_ARMY._15;
+        let heavy_infantry_health = army_unpacked.heavy_infantry.health * SHIFT_ARMY._16;
 
         let packed = heavy_infantry_health + light_infantry_health + arcanist_health + mage_health + longbow_health + archer_health + heavy_cavalry_health + light_cavalry_health + heavy_infantry_quantity + light_infantry_quantity + archanist_quantity + mage_quantity + longbow_quantity + archer_quantity + heavy_cavalry_quantity + light_cavalry_quantity;
         return (packed,);
@@ -176,27 +176,27 @@ namespace Combat {
 
         let (cavalry_attack) = calculate_attack_values(
             BattalionIds.LightCavalry,
-            unpacked_army.LightCavalry.Quantity,
+            unpacked_army.light_cavalry.quantity,
             BattalionIds.HeavyCavalry,
-            unpacked_army.HeavyCavalry.Quantity,
+            unpacked_army.heavy_cavalry.quantity,
         );
         let (archery_attack) = calculate_attack_values(
             BattalionIds.Archer,
-            unpacked_army.Archer.Quantity,
+            unpacked_army.archer.quantity,
             BattalionIds.Longbow,
-            unpacked_army.Longbow.Quantity,
+            unpacked_army.longbow.quantity,
         );
         let (magic_attack) = calculate_attack_values(
             BattalionIds.Mage,
-            unpacked_army.Mage.Quantity,
+            unpacked_army.mage.quantity,
             BattalionIds.Arcanist,
-            unpacked_army.Arcanist.Quantity,
+            unpacked_army.arcanist.quantity,
         );
         let (infantry_attack) = calculate_attack_values(
             BattalionIds.LightInfantry,
-            unpacked_army.LightInfantry.Quantity,
+            unpacked_army.light_infantry.quantity,
             BattalionIds.HeavyInfantry,
-            unpacked_army.HeavyInfantry.Quantity,
+            unpacked_army.heavy_infantry.quantity,
         );
 
         let (cavalry_defence, archer_defence, magic_defence, infantry_defence) = all_defence_value(
@@ -276,7 +276,7 @@ namespace Combat {
         alloc_locals;
 
         return (
-            army.LightCavalry.Quantity + army.HeavyCavalry.Quantity + army.Archer.Quantity + army.Longbow.Quantity + army.Mage.Quantity + army.Arcanist.Quantity + army.LightInfantry.Quantity + army.HeavyInfantry.Quantity,
+            army.light_cavalry.quantity + army.heavy_cavalry.quantity + army.archer.quantity + army.longbow.quantity + army.mage.quantity + army.arcanist.quantity + army.light_infantry.quantity + army.heavy_infantry.quantity,
         );
     }
 
@@ -292,25 +292,25 @@ namespace Combat {
 
         let (total_battalions) = calculate_total_battalions(army);
 
-        let c_defence = army.LightCavalry.Quantity * BattalionStatistics.Defence.Cavalry.LightCavalry + army.HeavyCavalry.Quantity * BattalionStatistics.Defence.Cavalry.HeavyCavalry + army.Archer.Quantity * BattalionStatistics.Defence.Cavalry.Archer + army.Longbow.Quantity * BattalionStatistics.Defence.Cavalry.Longbow + army.Mage.Quantity * BattalionStatistics.Defence.Cavalry.Mage + army.Arcanist.Quantity * BattalionStatistics.Defence.Cavalry.Arcanist + army.LightInfantry.Quantity * BattalionStatistics.Defence.Cavalry.LightInfantry + army.HeavyInfantry.Quantity * BattalionStatistics.Defence.Cavalry.HeavyInfantry;
+        let c_defence = army.light_cavalry.quantity * BattalionStatistics.Defence.Cavalry.LightCavalry + army.heavy_cavalry.quantity * BattalionStatistics.Defence.Cavalry.HeavyCavalry + army.archer.quantity * BattalionStatistics.Defence.Cavalry.Archer + army.longbow.quantity * BattalionStatistics.Defence.Cavalry.Longbow + army.mage.quantity * BattalionStatistics.Defence.Cavalry.Mage + army.arcanist.quantity * BattalionStatistics.Defence.Cavalry.Arcanist + army.light_infantry.quantity * BattalionStatistics.Defence.Cavalry.LightInfantry + army.heavy_infantry.quantity * BattalionStatistics.Defence.Cavalry.HeavyInfantry;
 
-        let a_defence = army.LightCavalry.Quantity * BattalionStatistics.Defence.Archery.LightCavalry + army.HeavyCavalry.Quantity * BattalionStatistics.Defence.Archery.HeavyCavalry + army.Archer.Quantity * BattalionStatistics.Defence.Archery.Archer + army.Longbow.Quantity * BattalionStatistics.Defence.Archery.Longbow + army.Mage.Quantity * BattalionStatistics.Defence.Archery.Mage + army.Arcanist.Quantity * BattalionStatistics.Defence.Archery.Arcanist + army.LightInfantry.Quantity * BattalionStatistics.Defence.Archery.LightInfantry + army.HeavyInfantry.Quantity * BattalionStatistics.Defence.Archery.HeavyInfantry;
+        let a_defence = army.light_cavalry.quantity * BattalionStatistics.Defence.Archery.LightCavalry + army.heavy_cavalry.quantity * BattalionStatistics.Defence.Archery.HeavyCavalry + army.archer.quantity * BattalionStatistics.Defence.Archery.Archer + army.longbow.quantity * BattalionStatistics.Defence.Archery.Longbow + army.mage.quantity * BattalionStatistics.Defence.Archery.Mage + army.arcanist.quantity * BattalionStatistics.Defence.Archery.Arcanist + army.light_infantry.quantity * BattalionStatistics.Defence.Archery.LightInfantry + army.heavy_infantry.quantity * BattalionStatistics.Defence.Archery.HeavyInfantry;
 
-        let m_defence = army.LightCavalry.Quantity * BattalionStatistics.Defence.Magic.LightCavalry + army.HeavyCavalry.Quantity * BattalionStatistics.Defence.Magic.HeavyCavalry + army.Archer.Quantity * BattalionStatistics.Defence.Magic.Archer + army.Longbow.Quantity * BattalionStatistics.Defence.Magic.Longbow + army.Mage.Quantity * BattalionStatistics.Defence.Magic.Mage + army.Arcanist.Quantity * BattalionStatistics.Defence.Magic.Arcanist + army.LightInfantry.Quantity * BattalionStatistics.Defence.Magic.LightInfantry + army.HeavyInfantry.Quantity * BattalionStatistics.Defence.Magic.HeavyInfantry;
+        let m_defence = army.light_cavalry.quantity * BattalionStatistics.Defence.Magic.LightCavalry + army.heavy_cavalry.quantity * BattalionStatistics.Defence.Magic.HeavyCavalry + army.archer.quantity * BattalionStatistics.Defence.Magic.Archer + army.longbow.quantity * BattalionStatistics.Defence.Magic.Longbow + army.mage.quantity * BattalionStatistics.Defence.Magic.Mage + army.arcanist.quantity * BattalionStatistics.Defence.Magic.Arcanist + army.light_infantry.quantity * BattalionStatistics.Defence.Magic.LightInfantry + army.heavy_infantry.quantity * BattalionStatistics.Defence.Magic.HeavyInfantry;
 
-        let i_defence = army.LightCavalry.Quantity * BattalionStatistics.Defence.Infantry.LightCavalry + army.HeavyCavalry.Quantity * BattalionStatistics.Defence.Infantry.HeavyCavalry + army.Archer.Quantity * BattalionStatistics.Defence.Infantry.Archer + army.Longbow.Quantity * BattalionStatistics.Defence.Infantry.Longbow + army.Mage.Quantity * BattalionStatistics.Defence.Infantry.Mage + army.Arcanist.Quantity * BattalionStatistics.Defence.Infantry.Arcanist + army.LightInfantry.Quantity * BattalionStatistics.Defence.Infantry.LightInfantry + army.HeavyInfantry.Quantity * BattalionStatistics.Defence.Infantry.HeavyInfantry;
+        let i_defence = army.light_cavalry.quantity * BattalionStatistics.Defence.Infantry.LightCavalry + army.heavy_cavalry.quantity * BattalionStatistics.Defence.Infantry.HeavyCavalry + army.archer.quantity * BattalionStatistics.Defence.Infantry.Archer + army.longbow.quantity * BattalionStatistics.Defence.Infantry.Longbow + army.mage.quantity * BattalionStatistics.Defence.Infantry.Mage + army.arcanist.quantity * BattalionStatistics.Defence.Infantry.Arcanist + army.light_infantry.quantity * BattalionStatistics.Defence.Infantry.LightInfantry + army.heavy_infantry.quantity * BattalionStatistics.Defence.Infantry.HeavyInfantry;
 
         let (cavalry_defence) = calculate_defence_values(
-            c_defence, total_battalions, army.LightCavalry.Quantity + army.HeavyCavalry.Quantity
+            c_defence, total_battalions, army.light_cavalry.quantity + army.heavy_cavalry.quantity
         );
         let (archer_defence) = calculate_defence_values(
-            a_defence, total_battalions, army.Archer.Quantity + army.Longbow.Quantity
+            a_defence, total_battalions, army.archer.quantity + army.longbow.quantity
         );
         let (magic_defence) = calculate_defence_values(
-            m_defence, total_battalions, army.Mage.Quantity + army.Arcanist.Quantity
+            m_defence, total_battalions, army.mage.quantity + army.arcanist.quantity
         );
         let (infantry_defence) = calculate_defence_values(
-            i_defence, total_battalions, army.LightInfantry.Quantity + army.HeavyInfantry.Quantity
+            i_defence, total_battalions, army.light_infantry.quantity + army.heavy_infantry.quantity
         );
         return (cavalry_defence, archer_defence, magic_defence, infantry_defence);
     }
@@ -338,16 +338,16 @@ namespace Combat {
         );
 
         let (cavalry_outcome) = calculate_luck_outcome(
-            luck, attack_army_statistics.CavalryAttack, defending_army_statistics.CavalryDefence
+            luck, attack_army_statistics.cavalry_attack, defending_army_statistics.cavalry_defence
         );
         let (archery_outcome) = calculate_luck_outcome(
-            luck, attack_army_statistics.ArcheryAttack, defending_army_statistics.ArcheryDefence
+            luck, attack_army_statistics.archery_attack, defending_army_statistics.archery_defence
         );
         let (magic_outcome) = calculate_luck_outcome(
-            luck, attack_army_statistics.MagicAttack, defending_army_statistics.MagicDefence
+            luck, attack_army_statistics.magic_attack, defending_army_statistics.magic_defence
         );
         let (infantry_outcome) = calculate_luck_outcome(
-            luck, attack_army_statistics.InfantryAttack, defending_army_statistics.InfantryDefence
+            luck, attack_army_statistics.infantry_attack, defending_army_statistics.infantry_defence
         );
 
         let final_outcome = cavalry_outcome + archery_outcome + magic_outcome + infantry_outcome;
@@ -497,60 +497,60 @@ namespace Combat {
         alloc_locals;
 
         let (light_cavalry_health, light_cavalry_battalions) = calculate_health_remaining(
-            attack_army_unpacked.LightCavalry.Health,
-            attack_army_unpacked.LightCavalry.Quantity,
-            attack_army_unpacked.LightCavalry.Quantity + attack_army_unpacked.HeavyCavalry.Quantity,
-            attack_army_statistics.InfantryAttack,
-            defending_army_statistics.InfantryDefence,
+            attack_army_unpacked.light_cavalry.health,
+            attack_army_unpacked.light_cavalry.quantity,
+            attack_army_unpacked.light_cavalry.quantity + attack_army_unpacked.heavy_cavalry.quantity,
+            attack_army_statistics.infantry_attack,
+            defending_army_statistics.infantry_defence,
         );
         let (heavy_cavalry_health, heavy_cavalry_battalions) = calculate_health_remaining(
-            attack_army_unpacked.HeavyCavalry.Health,
-            attack_army_unpacked.HeavyCavalry.Quantity,
-            attack_army_unpacked.LightCavalry.Quantity + attack_army_unpacked.HeavyCavalry.Quantity,
-            attack_army_statistics.InfantryAttack,
-            defending_army_statistics.InfantryDefence,
+            attack_army_unpacked.heavy_cavalry.health,
+            attack_army_unpacked.heavy_cavalry.quantity,
+            attack_army_unpacked.light_cavalry.quantity + attack_army_unpacked.heavy_cavalry.quantity,
+            attack_army_statistics.infantry_attack,
+            defending_army_statistics.infantry_defence,
         );
         let (archer_health, archer_battalions) = calculate_health_remaining(
-            attack_army_unpacked.Archer.Health,
-            attack_army_unpacked.Archer.Quantity,
-            attack_army_unpacked.Archer.Quantity + attack_army_unpacked.Longbow.Quantity,
-            attack_army_statistics.CavalryAttack,
-            defending_army_statistics.CavalryDefence,
+            attack_army_unpacked.archer.health,
+            attack_army_unpacked.archer.quantity,
+            attack_army_unpacked.archer.quantity + attack_army_unpacked.longbow.quantity,
+            attack_army_statistics.cavalry_attack,
+            defending_army_statistics.cavalry_defence,
         );
         let (longbow_health, longbow_battalions) = calculate_health_remaining(
-            attack_army_unpacked.Longbow.Health,
-            attack_army_unpacked.Longbow.Quantity,
-            attack_army_unpacked.Archer.Quantity + attack_army_unpacked.Longbow.Quantity,
-            attack_army_statistics.CavalryAttack,
-            defending_army_statistics.CavalryDefence,
+            attack_army_unpacked.longbow.health,
+            attack_army_unpacked.longbow.quantity,
+            attack_army_unpacked.archer.quantity + attack_army_unpacked.longbow.quantity,
+            attack_army_statistics.cavalry_attack,
+            defending_army_statistics.cavalry_defence,
         );
         let (mage_health, mage_battalions) = calculate_health_remaining(
-            attack_army_unpacked.Mage.Health,
-            attack_army_unpacked.Mage.Quantity,
-            attack_army_unpacked.Mage.Quantity + attack_army_unpacked.Arcanist.Quantity,
-            attack_army_statistics.ArcheryAttack,
-            defending_army_statistics.ArcheryDefence,
+            attack_army_unpacked.mage.health,
+            attack_army_unpacked.mage.quantity,
+            attack_army_unpacked.mage.quantity + attack_army_unpacked.arcanist.quantity,
+            attack_army_statistics.archery_attack,
+            defending_army_statistics.archery_defence,
         );
         let (archanist_health, archanist_battalions) = calculate_health_remaining(
-            attack_army_unpacked.Arcanist.Health,
-            attack_army_unpacked.Arcanist.Quantity,
-            attack_army_unpacked.Mage.Quantity + attack_army_unpacked.Arcanist.Quantity,
-            attack_army_statistics.ArcheryAttack,
-            defending_army_statistics.ArcheryDefence,
+            attack_army_unpacked.arcanist.health,
+            attack_army_unpacked.arcanist.quantity,
+            attack_army_unpacked.mage.quantity + attack_army_unpacked.arcanist.quantity,
+            attack_army_statistics.archery_attack,
+            defending_army_statistics.archery_defence,
         );
         let (light_infantry_health, light_infantry_battalions) = calculate_health_remaining(
-            attack_army_unpacked.LightInfantry.Health,
-            attack_army_unpacked.LightInfantry.Quantity,
-            attack_army_unpacked.LightInfantry.Quantity + attack_army_unpacked.LightInfantry.Quantity,
-            attack_army_statistics.InfantryAttack,
-            defending_army_statistics.InfantryDefence,
+            attack_army_unpacked.light_infantry.health,
+            attack_army_unpacked.light_infantry.quantity,
+            attack_army_unpacked.light_infantry.quantity + attack_army_unpacked.heavy_infantry.quantity,
+            attack_army_statistics.infantry_attack,
+            defending_army_statistics.infantry_defence,
         );
         let (heavy_infantry_health, heavy_infantry_battalions) = calculate_health_remaining(
-            attack_army_unpacked.HeavyInfantry.Health,
-            attack_army_unpacked.HeavyInfantry.Quantity,
-            attack_army_unpacked.HeavyInfantry.Quantity + attack_army_unpacked.HeavyInfantry.Quantity,
-            attack_army_statistics.MagicAttack,
-            defending_army_statistics.MagicDefence,
+            attack_army_unpacked.heavy_infantry.health,
+            attack_army_unpacked.heavy_infantry.quantity,
+            attack_army_unpacked.light_infantry.quantity + attack_army_unpacked.heavy_infantry.quantity,
+            attack_army_statistics.magic_attack,
+            defending_army_statistics.magic_defence,
         );
 
         let updated_attacking_army = Army(

--- a/contracts/settling_game/modules/combat/library.cairo
+++ b/contracts/settling_game/modules/combat/library.cairo
@@ -162,45 +162,42 @@ namespace Combat {
     }
 
     // @notice Gets statistics of Army
-    // @param army_packed: packed army
+    // @param army: An army
     // @returns ArmyStatistics which is a computed value
     func calculate_army_statistics{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-    }(army_packed: felt) -> (statistics: ArmyStatistics) {
+    }(army: Army) -> (statistics: ArmyStatistics) {
         alloc_locals;
-
-        let (unpacked_army: Army) = unpack_army(army_packed);
 
         let (cavalry_attack) = calculate_attack_values(
             BattalionIds.LightCavalry,
-            unpacked_army.light_cavalry.quantity,
+            army.light_cavalry.quantity,
             BattalionIds.HeavyCavalry,
-            unpacked_army.heavy_cavalry.quantity,
+            army.heavy_cavalry.quantity,
         );
         let (archery_attack) = calculate_attack_values(
             BattalionIds.Archer,
-            unpacked_army.archer.quantity,
+            army.archer.quantity,
             BattalionIds.Longbow,
-            unpacked_army.longbow.quantity,
+            army.longbow.quantity,
         );
         let (magic_attack) = calculate_attack_values(
             BattalionIds.Mage,
-            unpacked_army.mage.quantity,
+            army.mage.quantity,
             BattalionIds.Arcanist,
-            unpacked_army.arcanist.quantity,
+            army.arcanist.quantity,
         );
         let (infantry_attack) = calculate_attack_values(
             BattalionIds.LightInfantry,
-            unpacked_army.light_infantry.quantity,
+            army.light_infantry.quantity,
             BattalionIds.HeavyInfantry,
-            unpacked_army.heavy_infantry.quantity,
+            army.heavy_infantry.quantity,
         );
 
         let (cavalry_defence, archer_defence, magic_defence, infantry_defence) = all_defence_value(
-            unpacked_army
+            army
         );
 
         return (
@@ -214,7 +211,7 @@ namespace Combat {
     // @param unit_2_id: unit id 2
     // @param unit_2_number: number of units
     // @ returns attack value
-    func calculate_attack_values{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    func calculate_attack_values{range_check_ptr}(
         unit_1_id: felt, unit_1_number: felt, unit_2_id: felt, unit_2_number: felt
     ) -> (attack: felt) {
         alloc_locals;
@@ -228,7 +225,7 @@ namespace Combat {
     // @notice Gets attack value
     // @param battalion_id: Battalion ID
     // @ returns attack value
-    func attack_value{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    func attack_value{range_check_ptr}(
         battalion_id: felt
     ) -> (attack: felt) {
         alloc_locals;
@@ -317,55 +314,54 @@ namespace Combat {
 
     // @notice Calculates winner of battle
     // @param luck: Luck of Attacker - this is a number between 75-125 which adjusts the battle outcome
-    // @param attack_army_packed: Attacking Army packed
-    // @param defending_army_packed: Defending Army packed
-    // @return battle outcome (WIN or LOSS), packed attacking army, packed defending army
+    // @param attacking_army: Attacking Army
+    // @param defending_army: Defending Army
+    // @return battle outcome (WIN or LOSS), updated attacking army, updated defending army
     func calculate_winner{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-    }(luck: felt, attack_army_packed: felt, defending_army_packed: felt) -> (
-        outcome: felt, attack_army_packed: felt, defending_army_packed: felt
+    }(luck: felt, attacking_army: Army, defending_army: Army) -> (
+        outcome: felt, updated_attacking_army: Army, updated_defending_army: Army
     ) {
         alloc_locals;
 
-        let (attack_army_statistics: ArmyStatistics) = calculate_army_statistics(
-            attack_army_packed
+        let (attacking_army_statistics: ArmyStatistics) = calculate_army_statistics(
+            attacking_army
         );
         let (defending_army_statistics: ArmyStatistics) = calculate_army_statistics(
-            defending_army_packed
+            defending_army
         );
 
         let (cavalry_outcome) = calculate_luck_outcome(
-            luck, attack_army_statistics.cavalry_attack, defending_army_statistics.cavalry_defence
+            luck, attacking_army_statistics.cavalry_attack, defending_army_statistics.cavalry_defence
         );
         let (archery_outcome) = calculate_luck_outcome(
-            luck, attack_army_statistics.archery_attack, defending_army_statistics.archery_defence
+            luck, attacking_army_statistics.archery_attack, defending_army_statistics.archery_defence
         );
         let (magic_outcome) = calculate_luck_outcome(
-            luck, attack_army_statistics.magic_attack, defending_army_statistics.magic_defence
+            luck, attacking_army_statistics.magic_attack, defending_army_statistics.magic_defence
         );
         let (infantry_outcome) = calculate_luck_outcome(
-            luck, attack_army_statistics.infantry_attack, defending_army_statistics.infantry_defence
+            luck, attacking_army_statistics.infantry_attack, defending_army_statistics.infantry_defence
         );
 
         let final_outcome = cavalry_outcome + archery_outcome + magic_outcome + infantry_outcome;
 
         let successful = is_nn(final_outcome);
 
-        let (updated_attack_army_packed, updated_defence_army_packed) = get_updated_packed_armies(
-            attack_army_statistics,
+        let (updated_attacking_army) = update_army(
+            attacking_army_statistics,
             defending_army_statistics,
-            attack_army_packed,
-            defending_army_packed,
+            attacking_army,
+        );
+        let (updated_defending_army) = update_army(
+            defending_army_statistics,
+            attacking_army_statistics,
+            defending_army,
         );
 
-        if (successful == TRUE) {
-            return (TRUE, updated_attack_army_packed, updated_defence_army_packed);
-        }
-
-        return (FALSE, updated_attack_army_packed, updated_defence_army_packed);
+        return (successful, updated_attacking_army, updated_defending_army);
     }
 
     // @notice Calculates value after applying luck. All units use this.
@@ -438,117 +434,75 @@ namespace Combat {
         return (real_battalion_health, battalions);
     }
 
-    // @notice gets updated packed armies
+    // @notice updates Army
     // @param attack_army_statistics: ArmyStatistics of attacking Army
     // @param defending_army_statistics: ArmyStatistics of defending Army
-    // @param attack_army_packed: packed attacking Army
-    // @param defending_army_packed: packed defending Army
-    // @return packed attacking army, packed defending army
-    func get_updated_packed_armies{
+    // @param attack_army: Army to be updated
+    // @returns Army after it has had health modifier applied
+    func update_army{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
     }(
         attack_army_statistics: ArmyStatistics,
         defending_army_statistics: ArmyStatistics,
-        attack_army_packed: felt,
-        defending_army_packed: felt,
-    ) -> (attack_army_packed: felt, defending_army_packed: felt) {
-        alloc_locals;
-
-        let (attack_army_unpacked: Army) = unpack_army(attack_army_packed);
-        let (defending_army_unpacked: Army) = unpack_army(defending_army_packed);
-
-        let (attack_army_packed) = update_and_pack_army(
-            attack_army_statistics,
-            defending_army_statistics,
-            attack_army_unpacked,
-            defending_army_unpacked,
-        );
-
-        let (defence_army_packed) = update_and_pack_army(
-            defending_army_statistics,
-            attack_army_statistics,
-            defending_army_unpacked,
-            attack_army_unpacked,
-        );
-
-        return (attack_army_packed, defence_army_packed);
-    }
-
-    // @notice updates Army and packs
-    // @param attack_army_statistics: ArmyStatistics of attacking Army
-    // @param defending_army_statistics: ArmyStatistics of defending Army
-    // @param attack_army_unpacked: Attacking Army
-    // @param defending_army_unpacked: Defending Army
-    // @returns packed Army after it has had health modifier applied
-    func update_and_pack_army{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-        bitwise_ptr: BitwiseBuiltin*,
-    }(
-        attack_army_statistics: ArmyStatistics,
-        defending_army_statistics: ArmyStatistics,
-        attack_army_unpacked: Army,
-        defending_army_unpacked: Army,
-    ) -> (packed_army: felt) {
+        attack_army: Army,
+    ) -> (updated_army: Army) {
         alloc_locals;
 
         let (light_cavalry_health, light_cavalry_battalions) = calculate_health_remaining(
-            attack_army_unpacked.light_cavalry.health,
-            attack_army_unpacked.light_cavalry.quantity,
-            attack_army_unpacked.light_cavalry.quantity + attack_army_unpacked.heavy_cavalry.quantity,
+            attack_army.light_cavalry.health,
+            attack_army.light_cavalry.quantity,
+            attack_army.light_cavalry.quantity + attack_army.heavy_cavalry.quantity,
             attack_army_statistics.infantry_attack,
             defending_army_statistics.infantry_defence,
         );
         let (heavy_cavalry_health, heavy_cavalry_battalions) = calculate_health_remaining(
-            attack_army_unpacked.heavy_cavalry.health,
-            attack_army_unpacked.heavy_cavalry.quantity,
-            attack_army_unpacked.light_cavalry.quantity + attack_army_unpacked.heavy_cavalry.quantity,
+            attack_army.heavy_cavalry.health,
+            attack_army.heavy_cavalry.quantity,
+            attack_army.light_cavalry.quantity + attack_army.heavy_cavalry.quantity,
             attack_army_statistics.infantry_attack,
             defending_army_statistics.infantry_defence,
         );
         let (archer_health, archer_battalions) = calculate_health_remaining(
-            attack_army_unpacked.archer.health,
-            attack_army_unpacked.archer.quantity,
-            attack_army_unpacked.archer.quantity + attack_army_unpacked.longbow.quantity,
+            attack_army.archer.health,
+            attack_army.archer.quantity,
+            attack_army.archer.quantity + attack_army.longbow.quantity,
             attack_army_statistics.cavalry_attack,
             defending_army_statistics.cavalry_defence,
         );
         let (longbow_health, longbow_battalions) = calculate_health_remaining(
-            attack_army_unpacked.longbow.health,
-            attack_army_unpacked.longbow.quantity,
-            attack_army_unpacked.archer.quantity + attack_army_unpacked.longbow.quantity,
+            attack_army.longbow.health,
+            attack_army.longbow.quantity,
+            attack_army.archer.quantity + attack_army.longbow.quantity,
             attack_army_statistics.cavalry_attack,
             defending_army_statistics.cavalry_defence,
         );
         let (mage_health, mage_battalions) = calculate_health_remaining(
-            attack_army_unpacked.mage.health,
-            attack_army_unpacked.mage.quantity,
-            attack_army_unpacked.mage.quantity + attack_army_unpacked.arcanist.quantity,
+            attack_army.mage.health,
+            attack_army.mage.quantity,
+            attack_army.mage.quantity + attack_army.arcanist.quantity,
             attack_army_statistics.archery_attack,
             defending_army_statistics.archery_defence,
         );
         let (archanist_health, archanist_battalions) = calculate_health_remaining(
-            attack_army_unpacked.arcanist.health,
-            attack_army_unpacked.arcanist.quantity,
-            attack_army_unpacked.mage.quantity + attack_army_unpacked.arcanist.quantity,
+            attack_army.arcanist.health,
+            attack_army.arcanist.quantity,
+            attack_army.mage.quantity + attack_army.arcanist.quantity,
             attack_army_statistics.archery_attack,
             defending_army_statistics.archery_defence,
         );
         let (light_infantry_health, light_infantry_battalions) = calculate_health_remaining(
-            attack_army_unpacked.light_infantry.health,
-            attack_army_unpacked.light_infantry.quantity,
-            attack_army_unpacked.light_infantry.quantity + attack_army_unpacked.heavy_infantry.quantity,
+            attack_army.light_infantry.health,
+            attack_army.light_infantry.quantity,
+            attack_army.light_infantry.quantity + attack_army.heavy_infantry.quantity,
             attack_army_statistics.infantry_attack,
             defending_army_statistics.infantry_defence,
         );
         let (heavy_infantry_health, heavy_infantry_battalions) = calculate_health_remaining(
-            attack_army_unpacked.heavy_infantry.health,
-            attack_army_unpacked.heavy_infantry.quantity,
-            attack_army_unpacked.light_infantry.quantity + attack_army_unpacked.heavy_infantry.quantity,
+            attack_army.heavy_infantry.health,
+            attack_army.heavy_infantry.quantity,
+            attack_army.light_infantry.quantity + attack_army.heavy_infantry.quantity,
             attack_army_statistics.magic_attack,
             defending_army_statistics.magic_defence,
         );
@@ -572,9 +526,7 @@ namespace Combat {
             heavy_infantry_health),
         );
 
-        let (packed_army) = pack_army(updated_attacking_army);
-
-        return (packed_army,);
+        return (updated_attacking_army,);
     }
 
     // @notice Asserts can build battalions

--- a/contracts/settling_game/utils/game_structs.cairo
+++ b/contracts/settling_game/utils/game_structs.cairo
@@ -518,31 +518,31 @@ struct TravelInformation {
 }
 
 struct Battalion {
-    Quantity: felt,  // 1-23
-    Health: felt,  // 1-100
+    quantity: felt,  // 1-23
+    health: felt,  // 1-100
 }
 
 struct Army {
-    LightCavalry: Battalion,
-    HeavyCavalry: Battalion,
-    Archer: Battalion,
-    Longbow: Battalion,
-    Mage: Battalion,
-    Arcanist: Battalion,
-    LightInfantry: Battalion,
-    HeavyInfantry: Battalion,
+    light_cavalry: Battalion,
+    heavy_cavalry: Battalion,
+    archer: Battalion,
+    longbow: Battalion,
+    mage: Battalion,
+    arcanist: Battalion,
+    light_infantry: Battalion,
+    heavy_infantry: Battalion,
 }
 
 struct ArmyStatistics {
-    CavalryAttack: felt,  // (Light Cav Base Attack*Number of Attacking Light Cav Battalions)+(Heavy Cav Base Attack*Number of Attacking Heavy Cav Battalions)
-    ArcheryAttack: felt,  // (Archer Base Attack*Number of Attacking Archer Battalions)+(Longbow Base Attack*Number of Attacking Longbow Battalions)
-    MagicAttack: felt,  // (Mage Base Attack*Number of Attacking Mage Battalions)+(Arcanist Base Attack*Number of Attacking Arcanist Battalions)
-    InfantryAttack: felt,  // (Light Inf Base Attack*Number of Attacking Light Inf Battalions)+(Heavy Inf Base Attack*Number of Attacking Heavy Inf Battalions)
+    cavalry_attack: felt,  // (Light Cav Base Attack*Number of Attacking Light Cav Battalions)+(Heavy Cav Base Attack*Number of Attacking Heavy Cav Battalions)
+    archery_attack: felt,  // (Archer Base Attack*Number of Attacking Archer Battalions)+(Longbow Base Attack*Number of Attacking Longbow Battalions)
+    magic_attack: felt,  // (Mage Base Attack*Number of Attacking Mage Battalions)+(Arcanist Base Attack*Number of Attacking Arcanist Battalions)
+    infantry_attack: felt,  // (Light Inf Base Attack*Number of Attacking Light Inf Battalions)+(Heavy Inf Base Attack*Number of Attacking Heavy Inf Battalions)
 
-    CavalryDefence: felt,  // (Sum of all units Cavalry Defence*Percentage of Attacking Cav Battalions)
-    ArcheryDefence: felt,  // (Sum of all units Archery Defence*Percentage of Attacking Archery Battalions)
-    MagicDefence: felt,  // (Sum of all units Magic Cav Defence*Percentage of Attacking Magic Battalions)
-    InfantryDefence: felt,  // (Sum of all units Infantry Defence*Percentage of Attacking Infantry Battalions)
+    cavalry_defence: felt,  // (Sum of all units Cavalry Defence*Percentage of Attacking Cav Battalions)
+    archery_defence: felt,  // (Sum of all units Archery Defence*Percentage of Attacking Archery Battalions)
+    magic_defence: felt,  // (Sum of all units Magic Cav Defence*Percentage of Attacking Magic Battalions)
+    infantry_defence: felt,  // (Sum of all units Infantry Defence*Percentage of Attacking Infantry Battalions)
 }
 
 struct ArmyData {


### PR DESCRIPTION
This PR makes combat much more effective / cheaper in gas and also cleans up the combat library code a bunch.

The main thing the PR does is that it removes the packing & unpacking of `Army` between combat library calls. It's not necessary. The only packing and unpacking we need to do is when dealing with storage (either writing to or reading from). All internal (library) functions should work on unpacked values only. This rule applies to the whole codebase. It's much more effective this way.

I've also removed the unnecessary `defending_army_packed` parameter to `update_and_pack_army` (the function is now called `update_army`).

Should be merged after #234 as it builds on it.