### PR TITLE
fixes #237

### DIFF
--- a/scripts/setup_cli_env.sh
+++ b/scripts/setup_cli_env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## Run Modes ##
-# Import account from argentx
+# Import account from argentx (currently disabled)
 OPTION1_IMPORT_ARGENTX_ACCOUNT=1;
 # Generate new Account
 OPTION2_GENERATE_ACCOUNT=2;


### PR DESCRIPTION
Per #237 our setup script was corrupted by windows newline characters which is preventing bash from being able to run it.