### PR TITLE
chore: linting cairo files

### DIFF
--- a/contracts/settling_game/modules/example/library.cairo
+++ b/contracts/settling_game/modules/example/library.cairo
@@ -1,5 +1,5 @@
 // Example Library
-// 
+//
 //
 //
 // MIT License

--- a/contracts/settling_game/modules/travel/Travel.cairo
+++ b/contracts/settling_game/modules/travel/Travel.cairo
@@ -1,4 +1,4 @@
-//   Module.TRAVEL
+// Module.TRAVEL
 //   Logic for travel
 //   Assets must exist on the same point in space in order to interact with each other.
 //   Assets have nested selectors allowing (n) number of potential assets to spawn from a single asset.

--- a/contracts/settling_game/tokens/Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/Realms_ERC721_Mintable.cairo
@@ -125,9 +125,9 @@ func isApprovedForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
 }
 
 @view
-func tokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
-    tokenId: Uint256
-) -> (tokenURI_len: felt, tokenURI: felt*) {
+func tokenURI{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(tokenId: Uint256) -> (tokenURI_len: felt, tokenURI: felt*) {
     alloc_locals;
     let (name) = get_realm_name(tokenId);
     let (realm_data: RealmData) = fetch_realm_data(tokenId);

--- a/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
+++ b/contracts/settling_game/tokens/S_Realms_ERC721_Mintable.cairo
@@ -128,9 +128,9 @@ func isApprovedForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
 }
 
 @view
-func tokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
-    tokenId: Uint256
-) -> (tokenURI_len: felt, tokenURI: felt*) {
+func tokenURI{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(tokenId: Uint256) -> (tokenURI_len: felt, tokenURI: felt*) {
     alloc_locals;
     let (controller) = Module.controller_address();
     let (realms_address) = IModuleController.get_external_contract_address(
@@ -138,7 +138,9 @@ func tokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, b
     );
     let (realm_name) = IRealms.get_realm_name(realms_address, tokenId);
     let (realm_data: RealmData) = IRealms.fetch_realm_data(realms_address, tokenId);
-    let (tokenURI_len, tokenURI) = Uri.build(tokenId, realm_name, realm_data, Utils.RealmType.S_Realm);
+    let (tokenURI_len, tokenURI) = Uri.build(
+        tokenId, realm_name, realm_data, Utils.RealmType.S_Realm
+    );
     return (tokenURI_len, tokenURI);
 }
 


### PR DESCRIPTION
I ran `cairo-format` on all .cairo files, this is the result. Should fix the lint action.