### PR TITLE
fix: dont throw when pillaging resources in combat loop

### DIFF
--- a/contracts/settling_game/modules/resources/Resources.cairo
+++ b/contracts/settling_game/modules/resources/Resources.cairo
@@ -254,9 +254,9 @@ func pillage_resources{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     // Get all vault raidable
     let (_, resource_mint, total_vault_days, _) = get_all_vault_raidable(token_id);
 
-    // CHECK IS RAIDABLE
-    with_attr error_message("RESOURCES: NOTHING TO RAID!") {
-        assert_not_zero(total_vault_days);
+    // early return if there's nothing to raid
+    if (total_vault_days == 0) {
+        return ();
     }
 
     let (last_update) = ISettling.get_time_vault_staked(settling_logic_address, token_id);


### PR DESCRIPTION
Removing an assert that could throw in the combat flow when there's nothing to raid. That would cause the whole combat TX to revert, which is not desirable.