### PR TITLE
chore: update Lords ERC20

### DIFF
--- a/contracts/bridge/lords_l2.cairo
+++ b/contracts/bridge/lords_l2.cairo
@@ -1,7 +1,7 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.cairo.common.math import assert_le_felt, assert_not_equal
+from starkware.cairo.common.math import assert_not_equal
 from starkware.cairo.common.uint256 import Uint256, uint256_check
 from starkware.starknet.common.eth_utils import assert_eth_address_range
 from starkware.starknet.common.messages import send_message_to_l1
@@ -22,7 +22,7 @@ namespace IMintable {
 
 @contract_interface
 namespace IBurnable {
-    func burnFrom(owner: address, amount: Uint256) {
+    func burn_away(owner: address, amount: Uint256) {
     }
 }
 
@@ -85,7 +85,7 @@ func initiate_withdrawal{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_c
     let (lords_token: address) = lords.read();
     let (caller: address) = get_caller_address();
 
-    IBurnable.burnFrom(lords_token, caller, amount);
+    IBurnable.burn_away(lords_token, caller, amount);
 
     tempvar payload: felt* = new (PROCESS_WITHDRAWAL, l1_recipient, amount.low, amount.high);
     send_message_to_l1(bridge, 4, payload);

--- a/contracts/settling_game/tokens/Lords_ERC20_Mintable.cairo
+++ b/contracts/settling_game/tokens/Lords_ERC20_Mintable.cairo
@@ -9,6 +9,7 @@ from starkware.cairo.common.uint256 import Uint256
 
 from openzeppelin.access.accesscontrol.library import AccessControl
 from openzeppelin.token.erc20.library import ERC20
+from openzeppelin.utils.constants.library import DEFAULT_ADMIN_ROLE
 
 // roles used to validate access to mint and burn_away functions
 const MINT_ROLE = 'mint';
@@ -19,8 +20,10 @@ func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     name: felt, symbol: felt, decimals: felt, admin: felt
 ) {
     ERC20.initializer(name, symbol, decimals);
+
     AccessControl.initializer();
-    AccessControl._set_role_admin(admin);
+    AccessControl._grant_role(DEFAULT_ADMIN_ROLE, admin);
+
     return ();
 }
 

--- a/contracts/settling_game/tokens/Lords_ERC20_Mintable.cairo
+++ b/contracts/settling_game/tokens/Lords_ERC20_Mintable.cairo
@@ -1,42 +1,26 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts for Cairo v0.2.0 (token/erc20/ERC20_Upgradeable.cairo)
+// based on OpenZeppelin Contracts for Cairo v0.5.1 (token/erc20/presets/ERC20Mintable.cairo)
+// with project specific modifications
 
 %lang starknet
-%builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.uint256 import Uint256
 
+from openzeppelin.access.accesscontrol.library import AccessControl
 from openzeppelin.token.erc20.library import ERC20
 
-from openzeppelin.upgrades.library import Proxy
+// roles used to validate access to mint and burn_away functions
+const MINT_ROLE = 'mint';
+const BURN_AWAY_ROLE = 'burn_away';
 
-//
-// Initializer
-//
-
-@external
-func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    name: felt,
-    symbol: felt,
-    decimals: felt,
-    initial_supply: Uint256,
-    recipient: felt,
-    proxy_admin: felt,
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, decimals: felt, admin: felt
 ) {
     ERC20.initializer(name, symbol, decimals);
-    ERC20._mint(recipient, initial_supply);
-    Proxy.initializer(proxy_admin);
-    return ();
-}
-
-@external
-func upgrade{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    new_implementation: felt
-) {
-    Proxy.assert_only_admin();
-    Proxy._set_implementation_hash(new_implementation);
+    AccessControl.initializer();
+    AccessControl._set_role_admin(admin);
     return ();
 }
 
@@ -46,14 +30,12 @@ func upgrade{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 
 @view
 func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
-    let (name) = ERC20.name();
-    return (name,);
+    return ERC20.name();
 }
 
 @view
 func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
-    let (symbol) = ERC20.symbol();
-    return (symbol,);
+    return ERC20.symbol();
 }
 
 @view
@@ -61,31 +43,28 @@ func totalSupply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     totalSupply: Uint256
 ) {
     let (totalSupply: Uint256) = ERC20.total_supply();
-    return (totalSupply,);
+    return (totalSupply=totalSupply);
 }
 
 @view
 func decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
     decimals: felt
 ) {
-    let (decimals) = ERC20.decimals();
-    return (decimals,);
+    return ERC20.decimals();
 }
 
 @view
 func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(account: felt) -> (
     balance: Uint256
 ) {
-    let (balance: Uint256) = ERC20.balance_of(account);
-    return (balance,);
+    return ERC20.balance_of(account);
 }
 
 @view
 func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     owner: felt, spender: felt
 ) -> (remaining: Uint256) {
-    let (remaining: Uint256) = ERC20.allowance(owner, spender);
-    return (remaining,);
+    return ERC20.allowance(owner, spender);
 }
 
 //
@@ -96,48 +75,88 @@ func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     recipient: felt, amount: Uint256
 ) -> (success: felt) {
-    ERC20.transfer(recipient, amount);
-    return (TRUE,);
+    return ERC20.transfer(recipient, amount);
 }
 
 @external
 func transferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     sender: felt, recipient: felt, amount: Uint256
 ) -> (success: felt) {
-    ERC20.transfer_from(sender, recipient, amount);
-    return (TRUE,);
+    return ERC20.transfer_from(sender, recipient, amount);
 }
 
 @external
 func approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     spender: felt, amount: Uint256
 ) -> (success: felt) {
-    ERC20.approve(spender, amount);
-    return (TRUE,);
+    return ERC20.approve(spender, amount);
 }
 
 @external
 func increaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     spender: felt, added_value: Uint256
 ) -> (success: felt) {
-    ERC20.increase_allowance(spender, added_value);
-    return (TRUE,);
+    return ERC20.increase_allowance(spender, added_value);
 }
 
 @external
 func decreaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     spender: felt, subtracted_value: Uint256
 ) -> (success: felt) {
-    ERC20.decrease_allowance(spender, subtracted_value);
-    return (TRUE,);
+    return ERC20.decrease_allowance(spender, subtracted_value);
 }
 
 @external
 func mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     to: felt, amount: Uint256
 ) {
-    // TODO: better access control, not just Ownable, but ACL based
-    // Ownable.assert_only_owner()
+    AccessControl.assert_only_role(MINT_ROLE);
     ERC20._mint(to, amount);
+    return ();
+}
+
+// @notice Called when de-bridging $LORDS from L2 back to L1
+@external
+func burn_away{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, amount: Uint256
+) {
+    AccessControl.assert_only_role(BURN_AWAY_ROLE);
+    ERC20._burn(owner, amount);
+    return ();
+}
+
+//
+// Access Control public functions
+//
+
+@view
+func has_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, address: felt
+) -> (has_role: felt) {
+    let (authorized: felt) = AccessControl.has_role(role, address);
+    return (authorized,);
+}
+
+@external
+func grant_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, address: felt
+) {
+    AccessControl.grant_role(role, address);
+    return ();
+}
+
+@external
+func revoke_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, address: felt
+) {
+    AccessControl.revoke_role(role, address);
+    return ();
+}
+
+@external
+func renounce_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, address: felt
+) {
+    AccessControl.renounce_role(role, address);
     return ();
 }


### PR DESCRIPTION
Updates the L2 $LORDS contract:

* uses more granular access control lib instead of ownable (this enables the L2 bridge contract to call `mint` and `burn_away`)
* introduces a new protected `burn_away` function that the L2 bridge calls when bridging $LORDS from L2 back to L1
* exposes `has_role`, `grant_role`, `revoke_role` and `renounce_role` functions from the `AccessControl` library so they are publicly available
* removes upgradability / proxy from the ERC20 token
* removes the initial supply and recipient from the constructor, as the only way how to get L2 $LORDS should be by bridging (though this can be overridden by the `admin` and I'm not sure it's a good idea)