### PR TITLE
resolves #271: removes duplicate adventurer_balance

### DIFF
--- a/contracts/loot/adventurer/Adventurer.cairo
+++ b/contracts/loot/adventurer/Adventurer.cairo
@@ -76,11 +76,6 @@ func adventurer_static(adventurer_token_id: Uint256) -> (adventurer: AdventurerS
 func adventurer_dynamic(adventurer_token_id: Uint256) -> (adventurer: PackedAdventurerState) {
 }
 
-// balance of $LORDS
-@storage_var
-func adventurer_balance(adventurer_token_id: Uint256) -> (balance: Uint256) {
-}
-
 @storage_var
 func treasury_address() -> (address: felt) {
 }


### PR DESCRIPTION
Before fix:
```
$ nile compile /workspaces/realms-contracts/contracts/loot/adventurer/Adventurer.cairo

🔨 Compiling /workspaces/realms-contracts/contracts/loot/adventurer/Adventurer.cairo
/workspaces/realms-contracts/contracts/loot/adventurer/Adventurer.cairo:94:6: Found more than one storage variable with the same name ('adventurer_balance').
func adventurer_balance(tokenId: Uint256) -> (balance: Uint256) {
     ^****************^
/workspaces/realms-contracts/contracts/loot/adventurer/Adventurer.cairo:81:6: Note: another definition appears here.
func adventurer_balance(adventurer_token_id: Uint256) -> (balance: Uint256) {
     ^****************^
🛑 Failed to compile the following 1 contract:
   /workspaces/realms-contracts/contracts/loot/adventurer/Adventurer.cairo
```
   
After fix:
```
$ nile compile /workspaces/realms-contracts/contracts/loot/adventurer/Adventurer.cairo

🔨 Compiling /workspaces/realms-contracts/contracts/loot/adventurer/Adventurer.cairo
✅ Done
```